### PR TITLE
feat: Add `vaccel_config` bindings and update agent API

### DIFF
--- a/.github/workflows/validate-code.yml
+++ b/.github/workflows/validate-code.yml
@@ -18,6 +18,9 @@ on:
       runner-arch-map:
         type: string
         default: '[{"amd64":"x86_64", "arm64":"aarch64", "arm":"armv7l"}]'
+      clippy-features:
+        type: string
+        default: 'async,async-stream'
     secrets:
       GIT_CLONE_PAT:
         required: false
@@ -59,6 +62,13 @@ jobs:
           remote-actions-repo: ${{ inputs.actions-repo }}
           token: ${{ secrets.GIT_CLONE_PAT || github.token }}
 
+      # FIXME: Temp
+      - name: Install libcurl & stb
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev libstb-dev
+        shell: bash
+
       - name: Download artifacts from s3
         id: download-artifacts
         if: ${{ inputs.actions-repo != github.repository }}
@@ -73,7 +83,14 @@ jobs:
           install: 'true'
 
       - name: Run rust-clippy
-        run: cargo clippy --workspace --all-targets --all-features
+        run: |
+          cargo clippy --workspace --all-targets
+          cargo clippy --workspace --all-targets --all-features
+          IFS=','
+          features=${{ inputs.clippy-features }}
+          for f in $features; do
+            cargo clippy --workspace --all-targets --features "$f"
+          done
         shell: bash
 
       - name: Clean-up

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Crates implementing Rust interfaces for the vAccel C library:
 
 Install vAccel with:
 ```bash
-wget https://s3.nbfc.io/nbfc-assets/github/vaccel/rev/main/x86_64/release/vaccel_latest_x86_64.deb
-sudo dpkg -i vaccel_latest_x86_64.deb
+wget https://s3.nbfc.io/nbfc-assets/github/vaccel/rev/main/x86_64/release/vaccel_latest_amd64.deb
+sudo dpkg -i vaccel_latest_amd64.deb
 ```
 
 ## Build the components

--- a/vaccel-bindings/Cargo.toml
+++ b/vaccel-bindings/Cargo.toml
@@ -23,6 +23,7 @@ protobuf = "3.1"
 env_logger = "0.11"
 log = "0.4"
 libc = "0.2"
+thiserror = "1.0"
 
 [build-dependencies]
 libc = "0.2"

--- a/vaccel-bindings/src/config.rs
+++ b/vaccel-bindings/src/config.rs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{ffi, Error, Result};
+use log::warn;
+use std::{
+    ffi::{c_char, c_uint, CString},
+    ptr,
+};
+
+#[derive(Debug)]
+pub struct Config {
+    inner: ffi::vaccel_config,
+    initialized: bool,
+}
+
+// inner (`ffi::vaccel_config`) is only accessed through this (Config) struct's
+// methods and does not access TLS variables or global state so this should be
+// safe
+unsafe impl Send for Config {}
+
+impl Config {
+    /// Create a new resource object
+    pub fn new(
+        plugins: Option<&str>,
+        log_level: u8,
+        log_file: Option<&str>,
+        profiling_enabled: bool,
+        version_ignore: bool,
+    ) -> Result<Self> {
+        let plugins_cstr: CString;
+        let plugins_ptr: *const c_char;
+        match plugins {
+            Some(p) => {
+                plugins_cstr = CString::new(p).map_err(|_| Error::InvalidArgument)?;
+                plugins_ptr = plugins_cstr.as_c_str().as_ptr();
+            }
+            None => {
+                plugins_ptr = ptr::null();
+            }
+        };
+
+        let log_file_cstr: CString;
+        let log_file_ptr: *const c_char;
+        match log_file {
+            Some(l) => {
+                log_file_cstr = CString::new(l).map_err(|_| Error::InvalidArgument)?;
+                log_file_ptr = log_file_cstr.as_c_str().as_ptr();
+            }
+            None => {
+                log_file_ptr = ptr::null();
+            }
+        };
+
+        let mut inner = ffi::vaccel_config::default();
+        match unsafe {
+            ffi::vaccel_config_init(
+                &mut inner,
+                plugins_ptr,
+                log_level as c_uint,
+                log_file_ptr,
+                profiling_enabled,
+                version_ignore,
+            ) as u32
+        } {
+            ffi::VACCEL_OK => Ok(Config {
+                inner,
+                initialized: true,
+            }),
+            err => Err(Error::Runtime(err)),
+        }
+    }
+
+    /// Create new config from environment variables
+    pub fn from_env() -> Result<Self> {
+        let mut inner = ffi::vaccel_config::default();
+        match unsafe { ffi::vaccel_config_init_from_env(&mut inner) as u32 } {
+            ffi::VACCEL_OK => Ok(Config {
+                inner,
+                initialized: true,
+            }),
+            err => Err(Error::Runtime(err)),
+        }
+    }
+
+    /// Returns `true` if the config has been initialized
+    pub fn initialized(&self) -> bool {
+        self.initialized
+    }
+
+    /// Release config data
+    pub fn release(&mut self) -> Result<()> {
+        if !self.initialized {
+            return Err(Error::Uninitialized);
+        }
+
+        match unsafe { ffi::vaccel_config_release(&mut self.inner) as u32 } {
+            ffi::VACCEL_OK => {
+                self.initialized = false;
+                Ok(())
+            }
+            err => Err(Error::Runtime(err)),
+        }
+    }
+
+    // Warning: Do not copy internal raw pointers
+    pub(crate) fn inner(&self) -> &ffi::vaccel_config {
+        &self.inner
+    }
+
+    // Warning: Do not copy internal raw pointers
+    pub(crate) fn inner_mut(&mut self) -> &mut ffi::vaccel_config {
+        &mut self.inner
+    }
+}
+
+impl Drop for Config {
+    fn drop(&mut self) {
+        if self.initialized && self.release().is_err() {
+            warn!("Could not release config");
+        }
+    }
+}

--- a/vaccel-bindings/src/lib.rs
+++ b/vaccel-bindings/src/lib.rs
@@ -9,6 +9,7 @@
 use std::{fmt, slice};
 
 pub mod arg;
+pub mod config;
 pub mod ffi;
 pub mod file;
 pub mod ops;
@@ -17,6 +18,7 @@ pub mod resource;
 pub mod session;
 
 pub use arg::Arg;
+pub use config::Config;
 pub use file::File;
 pub use resource::Resource;
 pub use session::Session;
@@ -150,4 +152,29 @@ pub unsafe fn c_pointer_to_mut_slice<'a, T>(buf: *mut T, len: usize) -> Option<&
     } else {
         Some(unsafe { slice::from_raw_parts_mut(buf, len) })
     }
+}
+
+pub fn bootstrap_with_config(config: &mut Config) -> Result<()> {
+    match unsafe { ffi::vaccel_bootstrap_with_config(config.inner_mut()) as u32 } {
+        ffi::VACCEL_OK => Ok(()),
+        err => Err(Error::Runtime(err)),
+    }
+}
+
+pub fn bootstrap() -> Result<()> {
+    match unsafe { ffi::vaccel_bootstrap() as u32 } {
+        ffi::VACCEL_OK => Ok(()),
+        err => Err(Error::Runtime(err)),
+    }
+}
+
+pub fn cleanup() -> Result<()> {
+    match unsafe { ffi::vaccel_cleanup() as u32 } {
+        ffi::VACCEL_OK => Ok(()),
+        err => Err(Error::Runtime(err)),
+    }
+}
+
+pub fn is_initialized() -> bool {
+    unsafe { ffi::vaccel_is_initialized() }
 }

--- a/vaccel-bindings/src/lib.rs
+++ b/vaccel-bindings/src/lib.rs
@@ -7,6 +7,7 @@
 #![allow(improper_ctypes)]
 
 use std::{fmt, slice};
+use thiserror::Error as ThisError;
 
 pub mod arg;
 pub mod config;
@@ -23,44 +24,36 @@ pub use file::File;
 pub use resource::Resource;
 pub use session::Session;
 
-#[derive(Debug)]
+#[derive(ThisError, Debug)]
 pub enum Error {
-    // Error returned to us by vAccel runtime library
+    /// Error returned by the vAccel runtime library
+    #[error("vAccel runtime error: {0}")]
     Runtime(u32),
 
-    // We received an invalid argument
+    /// Invalid argument
+    #[error("Invalid argument")]
     InvalidArgument,
 
-    // Uninitialized vAccel object
+    /// Uninitialized vAccel object
+    #[error("Invalid argument")]
     Uninitialized,
 
-    // A TensorFlow error
+    /// TensorFlow error
     #[cfg(target_pointer_width = "64")]
+    #[error("TensorFlow error: {0:?}")]
     TensorFlow(ops::tensorflow::Code),
 
-    // A TensorFlow Lite error
+    /// TensorFlow Lite error
+    #[error("TensorFlow Lite error: {0:?}")]
     TensorFlowLite(ops::tensorflow::lite::Code),
 
-    // A PyTorch error
+    /// LibTorch error
+    #[error("Torch error: {0:?}")]
     Torch(ops::torch::Code),
 
-    // Other error types
+    /// Other error types
+    #[error("Error: {0}")]
     Others(String),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Error::Runtime(e) => write!(f, "vAccel runtime error: {}", e),
-            Error::InvalidArgument => write!(f, "Invalid argument"),
-            Error::Uninitialized => write!(f, "Uninitialized vAccel object"),
-            #[cfg(target_pointer_width = "64")]
-            Error::TensorFlow(e) => write!(f, "TensorFlow error: {:?}", e),
-            Error::TensorFlowLite(e) => write!(f, "TensorFlow Lite error: {:?}", e),
-            Error::Torch(e) => write!(f, "Torch error: {:?}", e),
-            Error::Others(e) => write!(f, "Error: {}", e),
-        }
-    }
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/vaccel-rpc-agent/src/agent.rs
+++ b/vaccel-rpc-agent/src/agent.rs
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{AgentService, Error, Result};
+use std::{
+    net::ToSocketAddrs,
+    sync::{Arc, Mutex},
+};
+#[cfg(feature = "async")]
+use ttrpc::asynchronous::Server;
+#[cfg(not(feature = "async"))]
+use ttrpc::sync::Server;
+use vaccel::Config as VaccelConfig;
+#[cfg(feature = "async")]
+use vaccel_rpc_proto::asynchronous::agent_ttrpc::create_agent_service;
+#[cfg(not(feature = "async"))]
+use vaccel_rpc_proto::sync::agent_ttrpc::create_agent_service;
+
+#[derive(Default)]
+pub struct Agent {
+    pub server_address: String,
+    vaccel_config: Arc<Mutex<Option<VaccelConfig>>>,
+    server: Option<Server>,
+}
+
+impl Agent {
+    pub fn new(server_address: &str) -> Self {
+        Self {
+            server_address: server_address.to_string(),
+            ..Default::default()
+        }
+    }
+
+    pub fn set_server_address(&mut self, address: &str) -> Result<&mut Self> {
+        if self.server.is_some() {
+            return Err(Error::AgentError(
+                "Cannot change server_address of initialized agent".to_string(),
+            ));
+        }
+        self.server_address = address.to_string();
+        Ok(self)
+    }
+
+    pub fn set_vaccel_config(&self, config: VaccelConfig) -> Result<&Self> {
+        if self.server.is_some() {
+            return Err(Error::AgentError(
+                "Cannot change vaccel_config of initialized agent".to_string(),
+            ));
+        }
+        let config_ref = self.vaccel_config.clone();
+        let mut conf = config_ref.lock().unwrap();
+        *conf = Some(config);
+        Ok(self)
+    }
+
+    #[cfg(not(feature = "async"))]
+    pub fn start(&mut self) -> Result<()> {
+        if self.server.is_none() {
+            self.vaccel_init()?;
+            self.server_init()?;
+        }
+
+        self.server.as_mut().unwrap().start().map_err(|e| e.into())
+    }
+
+    #[cfg(feature = "async")]
+    pub async fn start(&mut self) -> Result<()> {
+        if self.server.is_none() {
+            self.vaccel_init()?;
+            self.server_init()?;
+        }
+
+        self.server
+            .as_mut()
+            .unwrap()
+            .start()
+            .await
+            .map_err(|e| e.into())
+    }
+
+    #[cfg(not(feature = "async"))]
+    pub fn stop(&mut self) -> Result<()> {
+        match self.server.take() {
+            Some(server) => {
+                let server = server.stop_listen();
+                self.server = Some(server);
+                Ok(())
+            }
+            None => Err(Error::AgentError(
+                "Cannot stop uninitialized agent".to_string(),
+            )),
+        }
+    }
+
+    #[cfg(feature = "async")]
+    pub async fn stop(&mut self) -> Result<()> {
+        match self.server.as_mut() {
+            Some(server) => {
+                server.stop_listen().await;
+                Ok(())
+            }
+            None => Err(Error::AgentError(
+                "Cannot stop uninitialized agent".to_string(),
+            )),
+        }
+    }
+
+    #[cfg(not(feature = "async"))]
+    pub fn shutdown(&mut self) -> Result<()> {
+        match self.server.take() {
+            Some(server) => {
+                server.shutdown();
+                Ok(())
+            }
+            None => Err(Error::AgentError(
+                "Cannot shutdown uninitialized agent".to_string(),
+            )),
+        }
+    }
+
+    #[cfg(feature = "async")]
+    pub async fn shutdown(&mut self) -> Result<()> {
+        match self.server.take() {
+            Some(mut server) => server.shutdown().await.map_err(|e| e.into()),
+            None => Err(Error::AgentError(
+                "Cannot shutdown uninitialized agent".to_string(),
+            )),
+        }
+    }
+
+    fn server_init(&mut self) -> Result<()> {
+        if self.server.is_some() {
+            return Err(Error::AgentError(
+                "Server has already been initialized".to_string(),
+            ));
+        }
+
+        if self.server_address.is_empty() {
+            return Err(Error::AgentError(
+                "Server address cannot be empty".to_string(),
+            ));
+        }
+
+        let aservice = create_agent_service(Arc::new(AgentService::new()));
+        let resolved_uri = resolve_uri(&self.server_address)?;
+
+        let server: Server = Server::new()
+            .bind(&resolved_uri)?
+            .register_service(aservice);
+
+        self.server = Some(server);
+
+        Ok(())
+    }
+
+    fn vaccel_init(&mut self) -> Result<()> {
+        let mut vaccel_config = self.vaccel_config.lock().unwrap();
+        match vaccel_config.as_mut() {
+            Some(c) => vaccel::bootstrap_with_config(c),
+            None => {
+                if !vaccel::is_initialized() {
+                    vaccel::bootstrap()
+                } else {
+                    Ok(())
+                }
+            }
+        }?;
+        Ok(())
+    }
+}
+
+fn resolve_uri(uri: &str) -> Result<String> {
+    let parts: Vec<&str> = uri.split("://").collect();
+    if parts.len() != 2 {
+        return Err(Error::AgentError("Invalid server address uri".into()));
+    }
+
+    let scheme = parts[0].to_lowercase();
+    match scheme.as_str() {
+        "vsock" | "unix" => Ok(uri.to_string()),
+        "tcp" => {
+            let address = parts[1].to_lowercase();
+            let mut resolved = match address.to_socket_addrs() {
+                Ok(a) => a,
+                Err(e) => return Err(Error::AgentError(e.to_string())),
+            };
+            let resolved_address = match resolved.next() {
+                Some(a) => a.to_string(),
+                None => {
+                    return Err(Error::AgentError(
+                        "Could not resolve TCP server address".into(),
+                    ))
+                }
+            };
+
+            Ok(format!("{}://{}", scheme, resolved_address.as_str()))
+        }
+        _ => Err(Error::AgentError("Unsupported protocol".into())),
+    }
+}

--- a/vaccel-rpc-agent/src/agent_service.rs
+++ b/vaccel-rpc-agent/src/agent_service.rs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use dashmap::DashMap;
+use std::{default::Default, pin::Pin, sync::Arc};
+use vaccel::{profiling::ProfRegions, Resource, Session, VaccelId};
+use vaccel_rpc_proto::profiling::{ProfilingRequest, ProfilingResponse};
+
+#[derive(Clone, Debug)]
+pub struct AgentService {
+    pub(crate) sessions: Arc<DashMap<VaccelId, Box<Session>>>,
+    pub(crate) resources: Arc<DashMap<VaccelId, Pin<Box<Resource>>>>,
+    pub(crate) timers: Arc<DashMap<VaccelId, ProfRegions>>,
+}
+
+unsafe impl Sync for AgentService {}
+unsafe impl Send for AgentService {}
+
+impl AgentService {
+    pub(crate) fn new() -> Self {
+        AgentService {
+            sessions: Arc::new(DashMap::new()),
+            resources: Arc::new(DashMap::new()),
+            timers: Arc::new(DashMap::new()),
+        }
+    }
+
+    pub(crate) fn do_get_timers(&self, req: ProfilingRequest) -> ttrpc::Result<ProfilingResponse> {
+        let timers = self
+            .timers
+            .entry(req.session_id.into())
+            .or_insert_with(|| ProfRegions::new("vaccel-agent"));
+
+        Ok(ProfilingResponse {
+            result: Some(timers.clone().into()).into(),
+            ..Default::default()
+        })
+    }
+}

--- a/vaccel-rpc-agent/src/asynchronous/agent_service.rs
+++ b/vaccel-rpc-agent/src/asynchronous/agent_service.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::VaccelRpcAgent;
+use crate::AgentService;
 use async_trait::async_trait;
 use std::default::Default;
 #[allow(unused_imports)]
@@ -12,7 +12,7 @@ use vaccel_rpc_proto::tensorflow::{
     TensorflowModelUnloadResponse,
 };
 use vaccel_rpc_proto::{
-    asynchronous::{agent::VaccelEmpty, agent_ttrpc::RpcAgent},
+    asynchronous::{agent::EmptyResponse, agent_ttrpc},
     genop::{Arg, GenopRequest, GenopResponse},
     image::{ImageClassificationRequest, ImageClassificationResponse},
     profiling::{ProfilingRequest, ProfilingResponse},
@@ -26,7 +26,7 @@ use vaccel_rpc_proto::{
 use log::debug;
 
 #[async_trait]
-impl RpcAgent for VaccelRpcAgent {
+impl agent_ttrpc::AgentService for AgentService {
     async fn create_session(
         &self,
         _ctx: &::ttrpc::asynchronous::TtrpcContext,
@@ -39,7 +39,7 @@ impl RpcAgent for VaccelRpcAgent {
         &self,
         _ctx: &::ttrpc::asynchronous::TtrpcContext,
         req: UpdateSessionRequest,
-    ) -> ttrpc::Result<VaccelEmpty> {
+    ) -> ttrpc::Result<EmptyResponse> {
         self.do_update_session(req)
     }
 
@@ -47,7 +47,7 @@ impl RpcAgent for VaccelRpcAgent {
         &self,
         _ctx: &::ttrpc::asynchronous::TtrpcContext,
         req: DestroySessionRequest,
-    ) -> ttrpc::Result<VaccelEmpty> {
+    ) -> ttrpc::Result<EmptyResponse> {
         self.do_destroy_session(req)
     }
 
@@ -71,7 +71,7 @@ impl RpcAgent for VaccelRpcAgent {
         &self,
         _ctx: &::ttrpc::asynchronous::TtrpcContext,
         req: UnregisterResourceRequest,
-    ) -> ttrpc::Result<VaccelEmpty> {
+    ) -> ttrpc::Result<EmptyResponse> {
         self.do_unregister_resource(req)
     }
 

--- a/vaccel-rpc-agent/src/asynchronous/mod.rs
+++ b/vaccel-rpc-agent/src/asynchronous/mod.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: Apache-2.0
+
+mod agent_service;

--- a/vaccel-rpc-agent/src/cli.rs
+++ b/vaccel-rpc-agent/src/cli.rs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::Error;
+use clap::Parser;
+use std::str::FromStr;
+
+#[derive(Debug, Default, Parser)]
+#[command(name = "vAccel RPC Agent")]
+#[command(about = "A vAccel RPC agent that can respond to acceleration requests")]
+pub struct Cli {
+    #[arg(short = 'a')]
+    #[arg(long = "server-address")]
+    #[arg(help = "The server address in the format '<socket-type>://<host>:<port>'")]
+    #[arg(default_value = "tcp://127.0.0.1:65500")]
+    pub server_address: String,
+
+    #[arg(long = "vaccel-config")]
+    #[arg(help = "Configuration options passed to vAccel in the format 'opt1=value1,opt2=value2'")]
+    pub vaccel_config: Option<VaccelConfig>,
+}
+
+#[derive(Debug, Clone)]
+pub struct VaccelConfig {
+    pub plugins: Option<String>,
+    pub log_level: Option<u8>,
+    pub log_file: Option<String>,
+    pub profiling_enabled: Option<bool>,
+    pub version_ignore: Option<bool>,
+}
+
+impl FromStr for VaccelConfig {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut plugins = None;
+        let mut log_level = None;
+        let mut log_file = None;
+        let mut profiling_enabled = None;
+        let mut version_ignore = None;
+
+        for part in s.split(',') {
+            let mut kv = part.splitn(2, '=');
+            let key = kv
+                .next()
+                .ok_or(Error::CliError("Missing key".to_string()))?;
+            let value = kv
+                .next()
+                .ok_or(Error::CliError("Missing value".to_string()))?;
+            match key {
+                "plugins" => plugins = Some(value.to_string()),
+                "log_level" => {
+                    log_level = Some(value.parse::<u8>().map_err(|_| {
+                        Error::CliError(format!("Invalid integer for log_level: {}", value))
+                    })?)
+                }
+                "log_file" => log_file = Some(value.to_string()),
+                "profiling_enabled" => {
+                    profiling_enabled = Some(value.parse::<bool>().map_err(|_| {
+                        Error::CliError(format!("Invalid boolean for profiling_enabled: {}", value))
+                    })?)
+                }
+                "version_ignore" => {
+                    version_ignore = Some(value.parse::<bool>().map_err(|_| {
+                        Error::CliError(format!("Invalid boolean for version_ignore: {}", value))
+                    })?)
+                }
+                _ => return Err(Error::CliError(format!("Unknown key: {}", key))),
+            }
+        }
+
+        Ok(VaccelConfig {
+            plugins,
+            log_level,
+            log_file,
+            profiling_enabled,
+            version_ignore,
+        })
+    }
+}
+
+impl TryFrom<VaccelConfig> for vaccel::Config {
+    type Error = Error;
+
+    fn try_from(config: VaccelConfig) -> Result<Self, Self::Error> {
+        let plugins = config.plugins.as_deref();
+        let log_level = config.log_level.unwrap_or(0);
+        let log_file = config.log_file.as_deref();
+        let profiling_enabled = config.profiling_enabled.unwrap_or(false);
+        let version_ignore = config.version_ignore.unwrap_or(false);
+
+        Ok(vaccel::Config::new(
+            plugins,
+            log_level,
+            log_file,
+            profiling_enabled,
+            version_ignore,
+        )?)
+    }
+}

--- a/vaccel-rpc-agent/src/ops/genop.rs
+++ b/vaccel-rpc-agent/src/ops/genop.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ttrpc_error, vaccel_error, VaccelRpcAgent};
+use crate::{ttrpc_error, vaccel_error, AgentService};
 use log::info;
 use vaccel::{profiling::ProfRegions, Arg};
 use vaccel_rpc_proto::genop::{GenopRequest, GenopResponse, GenopResult};
 
-impl VaccelRpcAgent {
+impl AgentService {
     pub(crate) fn do_genop(&self, mut req: GenopRequest) -> ttrpc::Result<GenopResponse> {
         let mut sess = self
             .sessions

--- a/vaccel-rpc-agent/src/ops/image.rs
+++ b/vaccel-rpc-agent/src/ops/image.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ttrpc_error, VaccelRpcAgent};
+use crate::{ttrpc_error, AgentService};
 use log::{error, info};
 use vaccel_rpc_proto::image::{ImageClassificationRequest, ImageClassificationResponse};
 
-impl VaccelRpcAgent {
+impl AgentService {
     pub(crate) fn do_image_classification(
         &self,
         req: ImageClassificationRequest,

--- a/vaccel-rpc-agent/src/ops/tf.rs
+++ b/vaccel-rpc-agent/src/ops/tf.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ttrpc_error, vaccel_error, VaccelRpcAgent};
+use crate::{ttrpc_error, vaccel_error, AgentService};
 use log::debug;
 use vaccel::ops::{tensorflow as tf, ModelInitialize, ModelLoadUnload, ModelRun};
 use vaccel_rpc_proto::tensorflow::{
@@ -9,7 +9,7 @@ use vaccel_rpc_proto::tensorflow::{
     TensorflowModelUnloadRequest, TensorflowModelUnloadResponse,
 };
 
-impl VaccelRpcAgent {
+impl AgentService {
     pub(crate) fn do_tensorflow_model_load(
         &self,
         req: TensorflowModelLoadRequest,

--- a/vaccel-rpc-agent/src/ops/tflite.rs
+++ b/vaccel-rpc-agent/src/ops/tflite.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ttrpc_error, vaccel_error, VaccelRpcAgent};
+use crate::{ttrpc_error, vaccel_error, AgentService};
 use log::debug;
 use vaccel::ops::{tensorflow::lite as tflite, ModelInitialize, ModelLoadUnload, ModelRun};
 use vaccel_rpc_proto::tensorflow::{
@@ -9,7 +9,7 @@ use vaccel_rpc_proto::tensorflow::{
     TensorflowLiteModelUnloadRequest, TensorflowLiteModelUnloadResponse,
 };
 
-impl VaccelRpcAgent {
+impl AgentService {
     pub(crate) fn do_tflite_model_load(
         &self,
         req: TensorflowLiteModelLoadRequest,

--- a/vaccel-rpc-agent/src/ops/torch.rs
+++ b/vaccel-rpc-agent/src/ops/torch.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ttrpc_error, vaccel_error, VaccelRpcAgent};
+use crate::{ttrpc_error, vaccel_error, AgentService};
 use vaccel::ops::{torch, ModelInitialize, ModelRun};
 use vaccel_rpc_proto::torch::{
     TorchJitloadForwardRequest, TorchJitloadForwardResponse, TorchJitloadForwardResult, TorchTensor,
 };
 
-impl VaccelRpcAgent {
+impl AgentService {
     pub(crate) fn do_torch_jitload_forward(
         &self,
         req: TorchJitloadForwardRequest,

--- a/vaccel-rpc-agent/src/resource.rs
+++ b/vaccel-rpc-agent/src/resource.rs
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ttrpc_error, vaccel_error, VaccelRpcAgent};
+use crate::{ttrpc_error, vaccel_error, AgentService};
 use log::info;
 use vaccel::{File, Resource, VaccelId};
 #[cfg(feature = "async")]
-use vaccel_rpc_proto::asynchronous::agent::VaccelEmpty;
+use vaccel_rpc_proto::asynchronous::agent::EmptyResponse;
 #[cfg(not(feature = "async"))]
-use vaccel_rpc_proto::sync::agent::VaccelEmpty;
+use vaccel_rpc_proto::sync::agent::EmptyResponse;
 #[allow(unused_imports)]
 use vaccel_rpc_proto::{
     error::VaccelError,
     resource::{RegisterResourceRequest, RegisterResourceResponse, UnregisterResourceRequest},
 };
 
-impl VaccelRpcAgent {
+impl AgentService {
     pub(crate) fn do_register_resource(
         &self,
         req: RegisterResourceRequest,
@@ -108,7 +108,7 @@ impl VaccelRpcAgent {
     pub(crate) fn do_unregister_resource(
         &self,
         req: UnregisterResourceRequest,
-    ) -> ttrpc::Result<VaccelEmpty> {
+    ) -> ttrpc::Result<EmptyResponse> {
         let mut res = self
             .resources
             .get_mut(&req.resource_id.into())
@@ -145,7 +145,7 @@ impl VaccelRpcAgent {
             .map_err(|e| ttrpc_error(ttrpc::Code::INTERNAL, e.to_string()))?
             > 0
         {
-            return Ok(VaccelEmpty::new());
+            return Ok(EmptyResponse::new());
         }
 
         info!("Destroying resource {}", res.as_ref().id());
@@ -161,7 +161,7 @@ impl VaccelRpcAgent {
                         )
                     })?;
 
-                Ok(VaccelEmpty::new())
+                Ok(EmptyResponse::new())
             }
             Err(e) => Err(ttrpc_error(ttrpc::Code::INTERNAL, e.to_string())),
         }

--- a/vaccel-rpc-agent/src/session.rs
+++ b/vaccel-rpc-agent/src/session.rs
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ttrpc_error, VaccelRpcAgent};
+use crate::{ttrpc_error, AgentService};
 use dashmap::mapref::entry::Entry;
 use log::info;
 #[cfg(feature = "async")]
-use vaccel_rpc_proto::asynchronous::agent::VaccelEmpty;
+use vaccel_rpc_proto::asynchronous::agent::EmptyResponse;
 use vaccel_rpc_proto::session::{
     CreateSessionRequest, CreateSessionResponse, DestroySessionRequest, UpdateSessionRequest,
 };
 #[cfg(not(feature = "async"))]
-use vaccel_rpc_proto::sync::agent::VaccelEmpty;
+use vaccel_rpc_proto::sync::agent::EmptyResponse;
 
-impl VaccelRpcAgent {
+impl AgentService {
     pub(crate) fn do_create_session(
         &self,
         req: CreateSessionRequest,
@@ -34,7 +34,7 @@ impl VaccelRpcAgent {
     pub(crate) fn do_update_session(
         &self,
         req: UpdateSessionRequest,
-    ) -> ttrpc::Result<VaccelEmpty> {
+    ) -> ttrpc::Result<EmptyResponse> {
         let mut sess = self
             .sessions
             .get_mut(&req.session_id.into())
@@ -46,13 +46,13 @@ impl VaccelRpcAgent {
         info!("Updating hint {} for session {}", req.flags, req.session_id);
 
         sess.update(req.flags);
-        Ok(VaccelEmpty::new())
+        Ok(EmptyResponse::new())
     }
 
     pub(crate) fn do_destroy_session(
         &self,
         req: DestroySessionRequest,
-    ) -> ttrpc::Result<VaccelEmpty> {
+    ) -> ttrpc::Result<EmptyResponse> {
         let (_, mut sess) = self
             .sessions
             .remove(&req.session_id.into())
@@ -67,7 +67,7 @@ impl VaccelRpcAgent {
             Err(e) => Err(ttrpc_error(ttrpc::Code::INTERNAL, e.to_string())),
             Ok(()) => {
                 info!("Destroyed session {}", req.session_id);
-                Ok(VaccelEmpty::new())
+                Ok(EmptyResponse::new())
             }
         }
     }

--- a/vaccel-rpc-agent/src/sync/agent_service.rs
+++ b/vaccel-rpc-agent/src/sync/agent_service.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::VaccelRpcAgent;
+use crate::AgentService;
 #[allow(unused_imports)]
 use vaccel_rpc_proto::tensorflow::{
     TensorflowLiteModelLoadRequest, TensorflowLiteModelLoadResponse, TensorflowLiteModelRunRequest,
@@ -17,11 +17,11 @@ use vaccel_rpc_proto::{
     session::{
         CreateSessionRequest, CreateSessionResponse, DestroySessionRequest, UpdateSessionRequest,
     },
-    sync::{agent::VaccelEmpty, agent_ttrpc::RpcAgent},
+    sync::{agent::EmptyResponse, agent_ttrpc},
     torch::{TorchJitloadForwardRequest, TorchJitloadForwardResponse},
 };
 
-impl RpcAgent for VaccelRpcAgent {
+impl agent_ttrpc::AgentService for AgentService {
     fn create_session(
         &self,
         _ctx: &::ttrpc::sync::TtrpcContext,
@@ -34,7 +34,7 @@ impl RpcAgent for VaccelRpcAgent {
         &self,
         _ctx: &::ttrpc::TtrpcContext,
         req: UpdateSessionRequest,
-    ) -> ttrpc::Result<VaccelEmpty> {
+    ) -> ttrpc::Result<EmptyResponse> {
         self.do_update_session(req)
     }
 
@@ -42,7 +42,7 @@ impl RpcAgent for VaccelRpcAgent {
         &self,
         _ctx: &::ttrpc::sync::TtrpcContext,
         req: DestroySessionRequest,
-    ) -> ttrpc::Result<VaccelEmpty> {
+    ) -> ttrpc::Result<EmptyResponse> {
         self.do_destroy_session(req)
     }
 
@@ -66,7 +66,7 @@ impl RpcAgent for VaccelRpcAgent {
         &self,
         _ctx: &::ttrpc::sync::TtrpcContext,
         req: UnregisterResourceRequest,
-    ) -> ttrpc::Result<VaccelEmpty> {
+    ) -> ttrpc::Result<EmptyResponse> {
         self.do_unregister_resource(req)
     }
 

--- a/vaccel-rpc-agent/src/sync/mod.rs
+++ b/vaccel-rpc-agent/src/sync/mod.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: Apache-2.0
+
+mod agent_service;

--- a/vaccel-rpc-client/src/asynchronous/client.rs
+++ b/vaccel-rpc-client/src/asynchronous/client.rs
@@ -7,11 +7,11 @@ use std::{future::Future, sync::Arc};
 use tokio::runtime::Runtime;
 use ttrpc::context::Context;
 use vaccel::profiling::ProfRegions;
-use vaccel_rpc_proto::asynchronous::agent_ttrpc::RpcAgentClient;
+use vaccel_rpc_proto::asynchronous::agent_ttrpc::AgentServiceClient;
 
 #[repr(C)]
 pub struct VaccelRpcClient {
-    pub ttrpc_client: RpcAgentClient,
+    pub ttrpc_client: AgentServiceClient,
     pub timers: Arc<DashMap<i64, ProfRegions>>,
     pub runtime: Arc<Runtime>,
 }
@@ -27,7 +27,7 @@ impl VaccelRpcClient {
         let ttrpc_client = Self::create_ttrpc_client(&server_address)?;
 
         Ok(VaccelRpcClient {
-            ttrpc_client: RpcAgentClient::new(ttrpc_client),
+            ttrpc_client: AgentServiceClient::new(ttrpc_client),
             timers: Arc::new(DashMap::new()),
             runtime: Arc::new(r),
         })
@@ -35,7 +35,7 @@ impl VaccelRpcClient {
 
     pub fn execute<'a, 'b, F, A, R>(&'a self, func: F, ctx: Context, req: &'b A) -> R::Output
     where
-        F: Fn(&'a RpcAgentClient, Context, &'b A) -> R,
+        F: Fn(&'a AgentServiceClient, Context, &'b A) -> R,
         R: Future,
     {
         self.runtime

--- a/vaccel-rpc-client/src/ops/genop.rs
+++ b/vaccel-rpc-client/src/ops/genop.rs
@@ -9,10 +9,10 @@ use log::error;
 use std::{convert::TryInto, ffi::c_int, ptr};
 use vaccel::{c_pointer_to_mut_slice, c_pointer_to_slice, ffi};
 #[cfg(feature = "async")]
-use vaccel_rpc_proto::asynchronous::agent_ttrpc::RpcAgentClient;
+use vaccel_rpc_proto::asynchronous::agent_ttrpc::AgentServiceClient;
 use vaccel_rpc_proto::genop::{Arg, GenopRequest};
 #[cfg(not(feature = "async"))]
-use vaccel_rpc_proto::sync::agent_ttrpc::RpcAgentClient;
+use vaccel_rpc_proto::sync::agent_ttrpc::AgentServiceClient;
 
 impl VaccelRpcClient {
     pub fn genop(
@@ -33,7 +33,7 @@ impl VaccelRpcClient {
         self.timer_stop(sess_id, "genop > client > req create");
 
         self.timer_start(sess_id, "genop > client > ttrpc_client.genop");
-        let mut resp = self.execute(RpcAgentClient::genop, ctx, &req)?;
+        let mut resp = self.execute(AgentServiceClient::genop, ctx, &req)?;
         self.timer_stop(sess_id, "genop > client > ttrpc_client.genop");
         if resp.has_error() {
             return Err(resp.take_error().into());

--- a/vaccel-rpc-client/src/ops/image.rs
+++ b/vaccel-rpc-client/src/ops/image.rs
@@ -12,10 +12,10 @@ use std::{
 };
 use vaccel::ffi;
 #[cfg(feature = "async")]
-use vaccel_rpc_proto::asynchronous::agent_ttrpc::RpcAgentClient;
+use vaccel_rpc_proto::asynchronous::agent_ttrpc::AgentServiceClient;
 use vaccel_rpc_proto::image::ImageClassificationRequest;
 #[cfg(not(feature = "async"))]
-use vaccel_rpc_proto::sync::agent_ttrpc::RpcAgentClient;
+use vaccel_rpc_proto::sync::agent_ttrpc::AgentServiceClient;
 
 impl VaccelRpcClient {
     pub fn image_classify(&self, sess_id: i64, img: Vec<u8>) -> Result<Vec<u8>> {
@@ -26,7 +26,7 @@ impl VaccelRpcClient {
             ..Default::default()
         };
 
-        let resp = self.execute(RpcAgentClient::image_classification, ctx, &req)?;
+        let resp = self.execute(AgentServiceClient::image_classification, ctx, &req)?;
 
         Ok(resp.tags)
     }

--- a/vaccel-rpc-client/src/ops/tf.rs
+++ b/vaccel-rpc-client/src/ops/tf.rs
@@ -9,9 +9,9 @@ use log::error;
 use std::ffi::c_int;
 use vaccel::{c_pointer_to_mut_slice, c_pointer_to_slice, ffi};
 #[cfg(feature = "async")]
-use vaccel_rpc_proto::asynchronous::agent_ttrpc::RpcAgentClient;
+use vaccel_rpc_proto::asynchronous::agent_ttrpc::AgentServiceClient;
 #[cfg(not(feature = "async"))]
-use vaccel_rpc_proto::sync::agent_ttrpc::RpcAgentClient;
+use vaccel_rpc_proto::sync::agent_ttrpc::AgentServiceClient;
 use vaccel_rpc_proto::tensorflow::{
     TFNode, TFTensor, TensorflowModelLoadRequest, TensorflowModelRunRequest,
     TensorflowModelUnloadRequest,
@@ -26,7 +26,7 @@ impl VaccelRpcClient {
             ..Default::default()
         };
 
-        let mut resp = self.execute(RpcAgentClient::tensorflow_model_load, ctx, &req)?;
+        let mut resp = self.execute(AgentServiceClient::tensorflow_model_load, ctx, &req)?;
         if resp.has_error() {
             return Err(resp.take_error().into());
         }
@@ -42,7 +42,7 @@ impl VaccelRpcClient {
             ..Default::default()
         };
 
-        let mut resp = self.execute(RpcAgentClient::tensorflow_model_unload, ctx, &req)?;
+        let mut resp = self.execute(AgentServiceClient::tensorflow_model_unload, ctx, &req)?;
 
         match resp.error.take() {
             None => Ok(()),
@@ -71,7 +71,7 @@ impl VaccelRpcClient {
             ..Default::default()
         };
 
-        let mut resp = self.execute(RpcAgentClient::tensorflow_model_run, ctx, &req)?;
+        let mut resp = self.execute(AgentServiceClient::tensorflow_model_run, ctx, &req)?;
         if resp.has_error() {
             return Err(resp.take_error().into());
         }

--- a/vaccel-rpc-client/src/ops/tflite.rs
+++ b/vaccel-rpc-client/src/ops/tflite.rs
@@ -9,9 +9,9 @@ use log::error;
 use std::ffi::c_int;
 use vaccel::{c_pointer_to_mut_slice, c_pointer_to_slice, ffi};
 #[cfg(feature = "async")]
-use vaccel_rpc_proto::asynchronous::agent_ttrpc::RpcAgentClient;
+use vaccel_rpc_proto::asynchronous::agent_ttrpc::AgentServiceClient;
 #[cfg(not(feature = "async"))]
-use vaccel_rpc_proto::sync::agent_ttrpc::RpcAgentClient;
+use vaccel_rpc_proto::sync::agent_ttrpc::AgentServiceClient;
 use vaccel_rpc_proto::tensorflow::{
     TFLiteTensor, TensorflowLiteModelLoadRequest, TensorflowLiteModelRunRequest,
     TensorflowLiteModelUnloadRequest,
@@ -26,7 +26,7 @@ impl VaccelRpcClient {
             ..Default::default()
         };
 
-        let mut resp = self.execute(RpcAgentClient::tensorflow_lite_model_load, ctx, &req)?;
+        let mut resp = self.execute(AgentServiceClient::tensorflow_lite_model_load, ctx, &req)?;
         if resp.has_error() {
             return Err(resp.take_error().into());
         }
@@ -42,7 +42,7 @@ impl VaccelRpcClient {
             ..Default::default()
         };
 
-        let mut resp = self.execute(RpcAgentClient::tensorflow_lite_model_unload, ctx, &req)?;
+        let mut resp = self.execute(AgentServiceClient::tensorflow_lite_model_unload, ctx, &req)?;
         if resp.has_error() {
             return Err(resp.take_error().into());
         }
@@ -67,7 +67,7 @@ impl VaccelRpcClient {
             ..Default::default()
         };
 
-        let mut resp = self.execute(RpcAgentClient::tensorflow_lite_model_run, ctx, &req)?;
+        let mut resp = self.execute(AgentServiceClient::tensorflow_lite_model_run, ctx, &req)?;
         if resp.has_error() {
             return Err(resp.take_error().into());
         }

--- a/vaccel-rpc-client/src/ops/torch.rs
+++ b/vaccel-rpc-client/src/ops/torch.rs
@@ -9,9 +9,9 @@ use log::error;
 use std::ffi::c_int;
 use vaccel::{c_pointer_to_mut_slice, c_pointer_to_slice, ffi};
 #[cfg(feature = "async")]
-use vaccel_rpc_proto::asynchronous::agent_ttrpc::RpcAgentClient;
+use vaccel_rpc_proto::asynchronous::agent_ttrpc::AgentServiceClient;
 #[cfg(not(feature = "async"))]
-use vaccel_rpc_proto::sync::agent_ttrpc::RpcAgentClient;
+use vaccel_rpc_proto::sync::agent_ttrpc::AgentServiceClient;
 use vaccel_rpc_proto::torch::{TorchJitloadForwardRequest, TorchTensor};
 
 impl VaccelRpcClient {
@@ -34,7 +34,7 @@ impl VaccelRpcClient {
             ..Default::default()
         };
 
-        let mut resp = self.execute(RpcAgentClient::torch_jitload_forward, ctx, &req)?;
+        let mut resp = self.execute(AgentServiceClient::torch_jitload_forward, ctx, &req)?;
         if resp.has_error() {
             return Err(resp.take_error().into());
         }

--- a/vaccel-rpc-client/src/profiling.rs
+++ b/vaccel-rpc-client/src/profiling.rs
@@ -8,10 +8,10 @@ use crate::{Error, Result};
 use std::{collections::BTreeMap, ptr};
 use vaccel::{c_pointer_to_mut_slice, ffi, profiling::ProfRegions};
 #[cfg(feature = "async")]
-use vaccel_rpc_proto::asynchronous::agent_ttrpc::RpcAgentClient;
+use vaccel_rpc_proto::asynchronous::agent_ttrpc::AgentServiceClient;
 use vaccel_rpc_proto::profiling::ProfilingRequest;
 #[cfg(not(feature = "async"))]
-use vaccel_rpc_proto::sync::agent_ttrpc::RpcAgentClient;
+use vaccel_rpc_proto::sync::agent_ttrpc::AgentServiceClient;
 
 impl VaccelRpcClient {
     pub const TIMERS_PREFIX: &'static str = "vaccel-client";
@@ -62,7 +62,7 @@ impl VaccelRpcClient {
             ..Default::default()
         };
 
-        let mut resp = self.execute(RpcAgentClient::get_timers, ctx, &req)?;
+        let mut resp = self.execute(AgentServiceClient::get_timers, ctx, &req)?;
 
         match resp.result.take() {
             Some(r) => Ok(r.into()),

--- a/vaccel-rpc-client/src/resource.rs
+++ b/vaccel-rpc-client/src/resource.rs
@@ -9,10 +9,10 @@ use log::error;
 use std::ffi::{c_char, c_int, CStr};
 use vaccel::{c_pointer_to_slice, ffi};
 #[cfg(feature = "async")]
-use vaccel_rpc_proto::asynchronous::agent_ttrpc::RpcAgentClient;
+use vaccel_rpc_proto::asynchronous::agent_ttrpc::AgentServiceClient;
 use vaccel_rpc_proto::resource::{File, RegisterResourceRequest, UnregisterResourceRequest};
 #[cfg(not(feature = "async"))]
-use vaccel_rpc_proto::sync::agent_ttrpc::RpcAgentClient;
+use vaccel_rpc_proto::sync::agent_ttrpc::AgentServiceClient;
 
 impl VaccelRpcClient {
     pub fn resource_register(
@@ -31,7 +31,7 @@ impl VaccelRpcClient {
         req.resource_id = id;
         req.session_id = sess_id;
 
-        let mut resp = self.execute(RpcAgentClient::register_resource, ctx, &req)?;
+        let mut resp = self.execute(AgentServiceClient::register_resource, ctx, &req)?;
 
         match resp.has_error() {
             false => Ok(resp.resource_id()),
@@ -45,7 +45,7 @@ impl VaccelRpcClient {
         req.resource_id = res_id;
         req.session_id = sess_id;
 
-        let _resp = self.execute(RpcAgentClient::unregister_resource, ctx, &req)?;
+        let _resp = self.execute(AgentServiceClient::unregister_resource, ctx, &req)?;
 
         Ok(())
     }

--- a/vaccel-rpc-client/src/session.rs
+++ b/vaccel-rpc-client/src/session.rs
@@ -10,12 +10,12 @@ use log::error;
 use std::ffi::c_int;
 use vaccel::ffi;
 #[cfg(feature = "async")]
-use vaccel_rpc_proto::asynchronous::agent_ttrpc::RpcAgentClient;
+use vaccel_rpc_proto::asynchronous::agent_ttrpc::AgentServiceClient;
 use vaccel_rpc_proto::session::{
     CreateSessionRequest, DestroySessionRequest, UpdateSessionRequest,
 };
 #[cfg(not(feature = "async"))]
-use vaccel_rpc_proto::sync::agent_ttrpc::RpcAgentClient;
+use vaccel_rpc_proto::sync::agent_ttrpc::AgentServiceClient;
 //use tracing::{info, instrument, Instrument};
 
 impl VaccelRpcClient {
@@ -26,7 +26,7 @@ impl VaccelRpcClient {
             ..Default::default()
         };
 
-        let resp = self.execute(RpcAgentClient::create_session, ctx, &req)?;
+        let resp = self.execute(AgentServiceClient::create_session, ctx, &req)?;
 
         Ok(resp.session_id)
     }
@@ -39,7 +39,7 @@ impl VaccelRpcClient {
             ..Default::default()
         };
 
-        let _resp = self.execute(RpcAgentClient::update_session, ctx, &req)?;
+        let _resp = self.execute(AgentServiceClient::update_session, ctx, &req)?;
 
         Ok(())
     }
@@ -51,7 +51,7 @@ impl VaccelRpcClient {
             ..Default::default()
         };
 
-        let _resp = self.execute(RpcAgentClient::destroy_session, ctx, &req)?;
+        let _resp = self.execute(AgentServiceClient::destroy_session, ctx, &req)?;
 
         Ok(())
     }

--- a/vaccel-rpc-client/src/sync/client.rs
+++ b/vaccel-rpc-client/src/sync/client.rs
@@ -6,11 +6,11 @@ use log::debug;
 use std::sync::Arc;
 use ttrpc::context::Context;
 use vaccel::profiling::ProfRegions;
-use vaccel_rpc_proto::sync::agent_ttrpc::RpcAgentClient;
+use vaccel_rpc_proto::sync::agent_ttrpc::AgentServiceClient;
 
 #[repr(C)]
 pub struct VaccelRpcClient {
-    pub ttrpc_client: RpcAgentClient,
+    pub ttrpc_client: AgentServiceClient,
     pub timers: Arc<DashMap<i64, ProfRegions>>,
 }
 
@@ -22,14 +22,14 @@ impl VaccelRpcClient {
         let ttrpc_client = Self::create_ttrpc_client(&server_address)?;
 
         Ok(VaccelRpcClient {
-            ttrpc_client: RpcAgentClient::new(ttrpc_client),
+            ttrpc_client: AgentServiceClient::new(ttrpc_client),
             timers: Arc::new(DashMap::new()),
         })
     }
 
     pub fn execute<'a, 'b, F, A, R>(&'a self, func: F, ctx: Context, req: &'b A) -> R
     where
-        F: Fn(&'a RpcAgentClient, Context, &'b A) -> R,
+        F: Fn(&'a AgentServiceClient, Context, &'b A) -> R,
     {
         func(&self.ttrpc_client, ctx, req)
     }

--- a/vaccel-rpc-proto/protos/async/agent.proto
+++ b/vaccel-rpc-proto/protos/async/agent.proto
@@ -12,15 +12,15 @@ import "profiling.proto";
 
 package vaccel;
 
-service RpcAgent {
+service AgentService {
 	// Session handling
 	rpc CreateSession(CreateSessionRequest) returns (CreateSessionResponse);
-	rpc UpdateSession(UpdateSessionRequest) returns (VaccelEmpty);
-	rpc DestroySession(DestroySessionRequest) returns (VaccelEmpty);
+	rpc UpdateSession(UpdateSessionRequest) returns (EmptyResponse);
+	rpc DestroySession(DestroySessionRequest) returns (EmptyResponse);
 
 	// vAccel resource handling
 	rpc RegisterResource(RegisterResourceRequest) returns (RegisterResourceResponse);
-	rpc UnregisterResource(UnregisterResourceRequest) returns (VaccelEmpty);
+	rpc UnregisterResource(UnregisterResourceRequest) returns (EmptyResponse);
 
 	// Image Classification API
 	rpc ImageClassification(ImageClassificationRequest) returns (ImageClassificationResponse);
@@ -48,4 +48,4 @@ service RpcAgent {
 	rpc GetTimers(ProfilingRequest) returns (ProfilingResponse);
 }
 
-message VaccelEmpty {}
+message EmptyResponse {}

--- a/vaccel-rpc-proto/protos/sync/agent.proto
+++ b/vaccel-rpc-proto/protos/sync/agent.proto
@@ -12,15 +12,15 @@ import "profiling.proto";
 
 package vaccel;
 
-service RpcAgent {
+service AgentService {
 	// Session handling
 	rpc CreateSession(CreateSessionRequest) returns (CreateSessionResponse);
-	rpc UpdateSession(UpdateSessionRequest) returns (VaccelEmpty);
-	rpc DestroySession(DestroySessionRequest) returns (VaccelEmpty);
+	rpc UpdateSession(UpdateSessionRequest) returns (EmptyResponse);
+	rpc DestroySession(DestroySessionRequest) returns (EmptyResponse);
 
 	// vAccel resource handling
 	rpc RegisterResource(RegisterResourceRequest) returns (RegisterResourceResponse);
-	rpc UnregisterResource(UnregisterResourceRequest) returns (VaccelEmpty);
+	rpc UnregisterResource(UnregisterResourceRequest) returns (EmptyResponse);
 
 	// Image Classification API
 	rpc ImageClassification(ImageClassificationRequest) returns (ImageClassificationResponse);
@@ -47,4 +47,4 @@ service RpcAgent {
 	rpc GetTimers(ProfilingRequest) returns (ProfilingResponse);
 }
 
-message VaccelEmpty {}
+message EmptyResponse {}


### PR DESCRIPTION
Add `vaccel_config` bindings and rework agent API to support vaccel configuration.

Noteworthy changes:
- Implement `vaccel_config` bindings and add wrappers for `vaccel_bootstrap*()`/`vaccel_cleanup()` functions
- Consolidate agent related functions from `lib.rs` to new `Agent` struct and split to separate `agent.rs`
- Add API support for creating an `Agent` with a `vaccel_config` object  and initializing vaccel with the agent configuration
- Add CLI support for parsing vaccel config options and split implementation to `cli.rs`