### PR TITLE
fix(torch): Use correct data types for tensor struct

### DIFF
--- a/vaccel-bindings/examples/torch_inference.rs
+++ b/vaccel-bindings/examples/torch_inference.rs
@@ -36,7 +36,8 @@ fn main() -> utilities::Result<()> {
     let run_options = torch::Buffer::new(&[]); // vaccel torch buffer with data and size
                                                // TODO: in_tensor setting, use random inputs here,
                                                // but should be images instead
-    let in_tensor = torch::Tensor::<f32>::new(&[3 * 224 * 224]).with_data(&[1.0; 3 * 224 * 224])?;
+    let in_tensor =
+        torch::Tensor::<f32>::new(&[3 * 224 * 224])?.with_data(&[1.0; 3 * 224 * 224])?;
     info!("in_tensor dim: {}", in_tensor.nr_dims());
 
     let mut sess_args = torch::InferenceArgs::new();

--- a/vaccel-bindings/src/ops/torch/mod.rs
+++ b/vaccel-bindings/src/ops/torch/mod.rs
@@ -55,38 +55,17 @@ impl Code {
     }
 }
 
-/**************/
-/*  DataType  */
-/**************/
 #[derive(Debug, PartialEq, Default)]
 pub enum DataType {
-    UnknownValue(u32),
-    #[default]
-    Float,
-    //Double,
-    Int32,
     UInt8,
-    Int16,
     Int8,
-    /*
-    String,
-    Complex64,
-    Bool,
-    QInt8,
-    QUInt8,
-    QInt32,
-    BFloat16,
-    QInt16,
-    QUInt16,
-    UInt16,
-    Complex128,
-    Resource,
-    Variant,
-    */
+    Int16,
+    Int32,
     Int64,
     Half,
-    //UInt32,
-    //UInt64,
+    #[default]
+    Float,
+    UnknownValue(u32),
 }
 
 impl DataType {
@@ -99,23 +78,6 @@ impl DataType {
             DataType::Int64 => ffi::VACCEL_TORCH_LONG,
             DataType::Half => ffi::VACCEL_TORCH_HALF,
             DataType::Float => ffi::VACCEL_TORCH_FLOAT,
-
-            // DataType::Double => ffi::VACCEL_TORCH_DOUBLE,
-            // DataType::String => ffi::VACCEL_TORCH_STRING,
-            // DataType::Complex64 => ffi::VACCEL_TORCH_COMPLEX64,
-            // DataType::Bool => ffi::VACCEL_TORCH_BOOL,
-            // DataType::QInt8 => ffi::VACCEL_TORCH_QINT8,
-            // DataType::QUInt8 => ffi::VACCEL_TORCH_QUINT8,
-            // DataType::QInt32 => ffi::VACCEL_TORCH_QINT32,
-            // DataType::BFloat16 => ffi::VACCEL_TORCH_BFLOAT16,
-            // DataType::QInt16 => ffi::VACCEL_TORCH_QINT16,
-            // DataType::QUInt16 => ffi::VACCEL_TORCH_QUINT16,
-            // DataType::UInt16 => ffi::VACCEL_TORCH_UINT16,
-            // DataType::Complex128 => ffi::VACCEL_TORCH_COMPLEX128,
-            // DataType::Resource => ffi::VACCEL_TORCH_RESOURCE,
-            // DataType::Variant => ffi::VACCEL_TORCH_VARIANT,
-            // DataType::UInt32 => ffi::VACCEL_TORCH_UINT32,
-            // DataType::UInt64 => ffi::VACCEL_TORCH_UINT64,
             DataType::UnknownValue(c) => *c,
         }
     }
@@ -129,23 +91,6 @@ impl DataType {
             ffi::VACCEL_TORCH_LONG => DataType::Int64,
             ffi::VACCEL_TORCH_HALF => DataType::Half,
             ffi::VACCEL_TORCH_FLOAT => DataType::Float,
-
-            // ffi::VACCEL_TORCH_DOUBLE => DataType::Double,
-            // ffi::VACCEL_TORCH_STRING => DataType::String,
-            // ffi::VACCEL_TORCH_COMPLEX64 => DataType::Complex64,
-            // ffi::VACCEL_TORCH_BOOL => DataType::Bool,
-            // ffi::VACCEL_TORCH_QINT8 => DataType::QInt8,
-            // ffi::VACCEL_TORCH_QUINT8 => DataType::QUInt8,
-            // ffi::VACCEL_TORCH_QINT32 => DataType::QInt32,
-            // ffi::VACCEL_TORCH_BFLOAT16 => DataType::BFloat16,
-            // ffi::VACCEL_TORCH_QINT16 => DataType::QInt16,
-            // ffi::VACCEL_TORCH_QUINT16 => DataType::QUInt16,
-            // ffi::VACCEL_TORCH_UINT16 => DataType::UInt16,
-            // ffi::VACCEL_TORCH_COMPLEX128 => DataType::Complex128,
-            // ffi::VACCEL_TORCH_RESOURCE => DataType::Resource,
-            // ffi::VACCEL_TORCH_VARIANT => DataType::Variant,
-            // ffi::VACCEL_TORCH_UINT32 => DataType::UInt32,
-            // ffi::VACCEL_TORCH_UINT64 => DataType::UInt64,
             unknown => DataType::UnknownValue(unknown),
         }
     }

--- a/vaccel-bindings/src/ops/torch/model.rs
+++ b/vaccel-bindings/src/ops/torch/model.rs
@@ -93,7 +93,7 @@ impl InferenceResult {
 
         unsafe {
             Ok(TorchTensor {
-                dims: std::slice::from_raw_parts((*t).dims as *mut u32, (*t).nr_dims as usize)
+                dims: std::slice::from_raw_parts((*t).dims as *mut _, (*t).nr_dims as usize)
                     .to_owned(),
                 type_: TorchDataType::from_i32((*t).data_type as i32)
                     .unwrap()

--- a/vaccel-rpc-client/src/lib.rs
+++ b/vaccel-rpc-client/src/lib.rs
@@ -34,7 +34,11 @@ pub enum Error {
     #[error("Async error: {0}")]
     AsyncError(tokio::task::JoinError),
 
-    /// Host error
+    /// vAccel error
+    #[error("vAccel error: {0}")]
+    VaccelError(vaccel::Error),
+
+    /// Host vAccel runtime error
     #[error("Host vAccel error: {0}")]
     HostRuntimeError(u32),
 
@@ -49,6 +53,12 @@ pub enum Error {
     /// Undefined error
     #[error("Undefined error")]
     Undefined,
+}
+
+impl From<vaccel::Error> for Error {
+    fn from(err: vaccel::Error) -> Self {
+        Error::VaccelError(err)
+    }
 }
 
 impl From<ttrpc::Error> for Error {

--- a/vaccel-rpc-proto/protos/torch.proto
+++ b/vaccel-rpc-proto/protos/torch.proto
@@ -17,29 +17,6 @@ enum TorchDataType {
 	Int64 = 5;
 	Half = 6;
 	FLOAT = 7;
-
-	// DOUBLE = 2;
-	//INT32 = 3;  // Int32 tensors are always in 'host' memory.
-	// UINT8 = 4;
-	// INT16 = 5;
-	// INT8 = 6;
-	// STRING = 7;
-	// COMPLEX = 8;    // Old identifier kept for API backwards compatibility
-	// INT64 = 9;
-	// BOOL = 10;
-	// QINT8 = 11;     // Quantized int8
-	// QUINT8 = 12;    // Quantized uint8
-	// QINT32 = 13;    // Quantized int32
-	// BFLOAT16 = 14;  // Float32 truncated to 16 bits.  Only for cast ops.
-	// QINT16 = 15;    // Quantized int16
-	// QUINT16 = 16;   // Quantized uint16
-	// UINT16 = 17;
-	// COMPLEX128 = 18;  // Double-precision complex
-	// HALF = 19;
-	// RESOURCE = 20;
-	// VARIANT = 21;
-	// UINT32 = 22;
-	// UINT64 = 23;
 };
 
 message TorchTensor {
@@ -47,30 +24,10 @@ message TorchTensor {
 	bytes data = 1;
 
 	// Dimensions of the tensor
-	repeated uint32 dims = 2;
+	repeated int64 dims = 2;
 
 	// Data type
 	TorchDataType type = 3;
-
-	/*
-	// Data of the tensor
-	bytes data = 1;
-
-	// Size
-	uint64 size = 2;
-
-	// if we owned the data
-	uint32 owned = 3;
-	
-	// out_torch element size
-	int32 nr_dims = 4;
-
-	// Dimensions of the tensor
-	repeated uint64 dims = 5;
-
-	// Data type
-	TorchDataType type = 6;
-	*/
 };
 
 // Jitload_forward


### PR DESCRIPTION
Use correct data types for torch tensor variables in `vaccel-bindings`