### PR TITLE
refactor: Cleanup error variants and properly handle RPC errors

### DIFF
--- a/vaccel-bindings/Cargo.toml
+++ b/vaccel-bindings/Cargo.toml
@@ -18,12 +18,14 @@ default = ["profiling"]
 profiling = []
 
 [dependencies]
-vaccel-rpc-proto = { path = "../vaccel-rpc-proto" }
-protobuf = "3.1"
 env_logger = "0.11"
 log = "0.4"
 libc = "0.2"
+protobuf = "3.1"
+derive_more = { version = "2.0", features = ["display", "from", "into"] }
 thiserror = "1.0"
+
+vaccel-rpc-proto = { path = "../vaccel-rpc-proto" }
 
 [build-dependencies]
 libc = "0.2"

--- a/vaccel-bindings/src/config.rs
+++ b/vaccel-bindings/src/config.rs
@@ -31,7 +31,12 @@ impl Config {
         let plugins_ptr: *const c_char;
         match plugins {
             Some(p) => {
-                plugins_cstr = CString::new(p).map_err(|_| Error::InvalidArgument)?;
+                plugins_cstr = CString::new(p).map_err(|e| {
+                    Error::ConversionFailed(format!(
+                        "Could not convert `plugins` to `CString` [{}]",
+                        e
+                    ))
+                })?;
                 plugins_ptr = plugins_cstr.as_c_str().as_ptr();
             }
             None => {
@@ -43,7 +48,12 @@ impl Config {
         let log_file_ptr: *const c_char;
         match log_file {
             Some(l) => {
-                log_file_cstr = CString::new(l).map_err(|_| Error::InvalidArgument)?;
+                log_file_cstr = CString::new(l).map_err(|e| {
+                    Error::ConversionFailed(format!(
+                        "Could not convert `log_file` to `CString` [{}]",
+                        e
+                    ))
+                })?;
                 log_file_ptr = log_file_cstr.as_c_str().as_ptr();
             }
             None => {
@@ -66,7 +76,7 @@ impl Config {
                 inner,
                 initialized: true,
             }),
-            err => Err(Error::Runtime(err)),
+            err => Err(Error::Ffi(err)),
         }
     }
 
@@ -78,7 +88,7 @@ impl Config {
                 inner,
                 initialized: true,
             }),
-            err => Err(Error::Runtime(err)),
+            err => Err(Error::Ffi(err)),
         }
     }
 
@@ -98,7 +108,7 @@ impl Config {
                 self.initialized = false;
                 Ok(())
             }
-            err => Err(Error::Runtime(err)),
+            err => Err(Error::Ffi(err)),
         }
     }
 

--- a/vaccel-bindings/src/error.rs
+++ b/vaccel-bindings/src/error.rs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::ffi;
+use derive_more::Display;
+use thiserror::Error as ThisError;
+use vaccel_rpc_proto::error::{VaccelError, VaccelErrorType, VaccelStatus};
+
+#[derive(Debug, Clone, Default, Display)]
+#[display("{} ({})", message, code)]
+pub struct Status {
+    pub code: u8,
+    pub message: String,
+}
+
+impl Status {
+    pub fn new(code: u8, message: &str) -> Self {
+        Status {
+            code,
+            message: message.to_string(),
+        }
+    }
+}
+
+impl From<Status> for VaccelStatus {
+    fn from(status: Status) -> Self {
+        let mut vaccel_status = Self::new();
+        vaccel_status.code = status.code as u32;
+        vaccel_status.message = status.message;
+        vaccel_status
+    }
+}
+
+impl TryFrom<VaccelStatus> for Status {
+    type Error = Error;
+
+    fn try_from(status: VaccelStatus) -> Result<Self> {
+        Ok(Self::new(
+            status
+                .code
+                .try_into()
+                .map_err(|e| Error::ConversionFailed(format!("{}", e)))?,
+            &status.message,
+        ))
+    }
+}
+
+#[derive(ThisError, Debug, Clone)]
+pub enum Error {
+    #[error("FFI error: {0}")]
+    Ffi(u32),
+
+    #[error("FFI error: {error} [{status}]")]
+    FfiWithStatus { error: u32, status: Status },
+
+    #[error("Invalid argument: {0}")]
+    InvalidArgument(String),
+
+    #[error("Uninitialized object")]
+    Uninitialized,
+
+    #[error("Index out of bounds")]
+    OutOfBounds,
+
+    #[error("Empty value")]
+    EmptyValue,
+
+    #[error("Conversion failed: {0}")]
+    ConversionFailed(String),
+}
+
+impl Error {
+    pub fn get_status(&self) -> Option<&Status> {
+        match self {
+            Error::FfiWithStatus { status, .. } => Some(status),
+            _ => None,
+        }
+    }
+}
+
+impl From<VaccelError> for Error {
+    fn from(err: VaccelError) -> Self {
+        match err.type_.enum_value().ok() {
+            Some(VaccelErrorType::FFI) => Self::Ffi(err.ffi_error.unwrap_or(ffi::VACCEL_EBACKEND)),
+            Some(VaccelErrorType::FFI_WITH_STATUS) => {
+                let status = match err.status.into_option() {
+                    Some(s) => {
+                        let code = u8::try_from(s.code).unwrap_or(u8::MAX);
+                        Status::new(code, &s.message)
+                    }
+                    None => Status::default(),
+                };
+
+                Self::FfiWithStatus {
+                    error: err.ffi_error.unwrap_or(ffi::VACCEL_EBACKEND),
+                    status,
+                }
+            }
+            Some(VaccelErrorType::INVALID_ARGUMENT) => {
+                let message = match err.status.into_option() {
+                    Some(s) => s.message,
+                    None => String::new(),
+                };
+
+                Self::InvalidArgument(message)
+            }
+            Some(VaccelErrorType::UNINITIALIZED) => Self::Uninitialized,
+            Some(VaccelErrorType::OUT_OF_BOUNDS) => Self::OutOfBounds,
+            Some(VaccelErrorType::EMPTY_VALUE) => Self::EmptyValue,
+            Some(VaccelErrorType::CONVERSION_FAILED) => {
+                let message = match err.status.into_option() {
+                    Some(s) => s.message,
+                    None => String::new(),
+                };
+
+                Self::ConversionFailed(message)
+            }
+            None => {
+                Self::ConversionFailed("Could not convert `Error` to `VaccelError`".to_string())
+            }
+        }
+    }
+}
+
+impl From<Error> for VaccelError {
+    fn from(err: Error) -> Self {
+        let mut vaccel_error = VaccelError::new();
+        match err {
+            Error::Ffi(error) => {
+                vaccel_error.type_ = VaccelErrorType::FFI.into();
+                vaccel_error.ffi_error = Some(error);
+            }
+            Error::FfiWithStatus { error, status } => {
+                vaccel_error.type_ = VaccelErrorType::FFI_WITH_STATUS.into();
+                vaccel_error.ffi_error = Some(error);
+                vaccel_error.status = Some(status.into()).into();
+            }
+            Error::InvalidArgument(message) => {
+                vaccel_error.type_ = VaccelErrorType::INVALID_ARGUMENT.into();
+                let mut status = VaccelStatus::new();
+                status.message = message;
+                vaccel_error.status = Some(status).into();
+            }
+            Error::Uninitialized => {
+                vaccel_error.type_ = VaccelErrorType::UNINITIALIZED.into();
+            }
+            Error::OutOfBounds => {
+                vaccel_error.type_ = VaccelErrorType::OUT_OF_BOUNDS.into();
+            }
+            Error::EmptyValue => {
+                vaccel_error.type_ = VaccelErrorType::EMPTY_VALUE.into();
+            }
+            Error::ConversionFailed(message) => {
+                vaccel_error.type_ = VaccelErrorType::CONVERSION_FAILED.into();
+                let mut status = VaccelStatus::new();
+                status.message = message;
+                vaccel_error.status = Some(status).into();
+            }
+        }
+        vaccel_error
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/vaccel-bindings/src/lib.rs
+++ b/vaccel-bindings/src/lib.rs
@@ -35,7 +35,7 @@ pub enum Error {
     InvalidArgument,
 
     /// Uninitialized vAccel object
-    #[error("Invalid argument")]
+    #[error("Uninitialized")]
     Uninitialized,
 
     /// TensorFlow error

--- a/vaccel-bindings/src/ops/genop.rs
+++ b/vaccel-bindings/src/ops/genop.rs
@@ -38,7 +38,7 @@ impl Session {
             res as u32
         } {
             ffi::VACCEL_OK => Ok(()),
-            err => Err(Error::Runtime(err)),
+            err => Err(Error::Ffi(err)),
         }
     }
 }

--- a/vaccel-bindings/src/ops/image.rs
+++ b/vaccel-bindings/src/ops/image.rs
@@ -27,7 +27,7 @@ impl Session {
             ) as u32
         } {
             ffi::VACCEL_OK => Ok((tags, out_img)),
-            err => Err(Error::Runtime(err)),
+            err => Err(Error::Ffi(err)),
         }
     }
 
@@ -44,7 +44,7 @@ impl Session {
             ) as u32
         } {
             ffi::VACCEL_OK => Ok(out_img),
-            err => Err(Error::Runtime(err)),
+            err => Err(Error::Ffi(err)),
         }
     }
 
@@ -61,7 +61,7 @@ impl Session {
             ) as u32
         } {
             ffi::VACCEL_OK => Ok(out_img),
-            err => Err(Error::Runtime(err)),
+            err => Err(Error::Ffi(err)),
         }
     }
 }

--- a/vaccel-bindings/src/ops/mod.rs
+++ b/vaccel-bindings/src/ops/mod.rs
@@ -28,10 +28,10 @@ pub trait ModelRun<'a>: ModelInitialize<'a> {
 }
 
 pub trait ModelLoadUnload<'a>: ModelRun<'a> {
-    type LoadResult;
+    type LoadUnloadResult;
 
     /// Load an inference session for model
-    fn load(self: Pin<&mut Self>, sess: &mut Session) -> Result<Self::LoadResult>;
+    fn load(self: Pin<&mut Self>, sess: &mut Session) -> Result<Self::LoadUnloadResult>;
     /// Unload an inference session for model
-    fn unload(self: Pin<&mut Self>, sess: &mut Session) -> Result<()>;
+    fn unload(self: Pin<&mut Self>, sess: &mut Session) -> Result<Self::LoadUnloadResult>;
 }

--- a/vaccel-bindings/src/ops/noop.rs
+++ b/vaccel-bindings/src/ops/noop.rs
@@ -10,7 +10,7 @@ impl vaccel_session {
     pub fn noop(&mut self) -> Result<()> {
         match unsafe { vaccel_noop(self) as u32 } {
             VACCEL_OK => Ok(()),
-            err => Err(Error::Runtime(err)),
+            err => Err(Error::Ffi(err)),
         }
     }
 }

--- a/vaccel-bindings/src/ops/tensorflow/buffer.rs
+++ b/vaccel-bindings/src/ops/tensorflow/buffer.rs
@@ -15,7 +15,7 @@ impl Buffer {
             ffi::vaccel_tf_buffer_new(&mut inner, data.as_ptr() as *mut _, data.len()) as u32
         } {
             ffi::VACCEL_OK => (),
-            err => return Err(Error::Runtime(err)),
+            err => return Err(Error::Ffi(err)),
         }
         assert!(!inner.is_null());
         unsafe { assert!(!(*inner).data.is_null()) };
@@ -33,7 +33,9 @@ impl Buffer {
     /// manually or by the respective vAccel function.
     pub unsafe fn from_ffi(buffer: *mut ffi::vaccel_tf_buffer) -> Result<Self> {
         if buffer.is_null() || (*buffer).data.is_null() || (*buffer).size == 0 {
-            return Err(Error::InvalidArgument);
+            return Err(Error::InvalidArgument(
+                "`buffer`, `buffer.data` and `buffer.size` cannot be `null`".to_string(),
+            ));
         }
 
         Ok(Buffer {

--- a/vaccel-bindings/src/ops/tensorflow/lite/mod.rs
+++ b/vaccel-bindings/src/ops/tensorflow/lite/mod.rs
@@ -3,42 +3,15 @@
 use crate::ffi;
 
 pub mod model;
+pub mod status;
 pub mod tensor;
 
 pub use model::{InferenceArgs, InferenceResult, Model};
+pub use status::Status;
 pub use tensor::{Tensor, TensorAny, TensorType};
 
-#[derive(Debug)]
-pub enum Code {
-    Ok = 0,
-    Error,
-    DelegateError,
-    ApplicationError,
-    DelegateDataNotFound,
-    DelegateDataWriteError,
-    DelegateDataReadError,
-    UnresolvedOps,
-    Cancelled,
-}
-
-impl Code {
-    pub(crate) fn to_u8(&self) -> u8 {
-        match self {
-            Code::Ok => 0,
-            Code::Error => 1,
-            Code::DelegateError => 2,
-            Code::ApplicationError => 3,
-            Code::DelegateDataNotFound => 4,
-            Code::DelegateDataWriteError => 5,
-            Code::DelegateDataReadError => 6,
-            Code::UnresolvedOps => 7,
-            Code::Cancelled => 8,
-        }
-    }
-}
-
 #[derive(Debug, PartialEq, Default)]
-pub enum Type {
+pub enum DataType {
     UnknownValue(u32),
     NoType,
     #[default]
@@ -62,54 +35,54 @@ pub enum Type {
     Int4,
 }
 
-impl Type {
+impl DataType {
     pub fn to_int(&self) -> u32 {
         match self {
-            Type::NoType => ffi::VACCEL_TFLITE_NOTYPE,
-            Type::Float32 => ffi::VACCEL_TFLITE_FLOAT32,
-            Type::Int32 => ffi::VACCEL_TFLITE_INT32,
-            Type::UInt8 => ffi::VACCEL_TFLITE_UINT8,
-            Type::Int64 => ffi::VACCEL_TFLITE_INT64,
-            Type::String => ffi::VACCEL_TFLITE_STRING,
-            Type::Bool => ffi::VACCEL_TFLITE_BOOL,
-            Type::Int16 => ffi::VACCEL_TFLITE_INT16,
-            Type::Complex64 => ffi::VACCEL_TFLITE_COMPLEX64,
-            Type::Int8 => ffi::VACCEL_TFLITE_INT8,
-            Type::Float16 => ffi::VACCEL_TFLITE_FLOAT16,
-            Type::Float64 => ffi::VACCEL_TFLITE_FLOAT64,
-            Type::Complex128 => ffi::VACCEL_TFLITE_COMPLEX128,
-            Type::UInt64 => ffi::VACCEL_TFLITE_UINT64,
-            Type::Resource => ffi::VACCEL_TFLITE_RESOURCE,
-            Type::Variant => ffi::VACCEL_TFLITE_VARIANT,
-            Type::UInt32 => ffi::VACCEL_TFLITE_UINT32,
-            Type::UInt16 => ffi::VACCEL_TFLITE_UINT16,
-            Type::Int4 => ffi::VACCEL_TFLITE_INT4,
-            Type::UnknownValue(c) => *c,
+            DataType::NoType => ffi::VACCEL_TFLITE_NOTYPE,
+            DataType::Float32 => ffi::VACCEL_TFLITE_FLOAT32,
+            DataType::Int32 => ffi::VACCEL_TFLITE_INT32,
+            DataType::UInt8 => ffi::VACCEL_TFLITE_UINT8,
+            DataType::Int64 => ffi::VACCEL_TFLITE_INT64,
+            DataType::String => ffi::VACCEL_TFLITE_STRING,
+            DataType::Bool => ffi::VACCEL_TFLITE_BOOL,
+            DataType::Int16 => ffi::VACCEL_TFLITE_INT16,
+            DataType::Complex64 => ffi::VACCEL_TFLITE_COMPLEX64,
+            DataType::Int8 => ffi::VACCEL_TFLITE_INT8,
+            DataType::Float16 => ffi::VACCEL_TFLITE_FLOAT16,
+            DataType::Float64 => ffi::VACCEL_TFLITE_FLOAT64,
+            DataType::Complex128 => ffi::VACCEL_TFLITE_COMPLEX128,
+            DataType::UInt64 => ffi::VACCEL_TFLITE_UINT64,
+            DataType::Resource => ffi::VACCEL_TFLITE_RESOURCE,
+            DataType::Variant => ffi::VACCEL_TFLITE_VARIANT,
+            DataType::UInt32 => ffi::VACCEL_TFLITE_UINT32,
+            DataType::UInt16 => ffi::VACCEL_TFLITE_UINT16,
+            DataType::Int4 => ffi::VACCEL_TFLITE_INT4,
+            DataType::UnknownValue(c) => *c,
         }
     }
 
-    pub fn from_int(val: u32) -> Type {
+    pub fn from_int(val: u32) -> DataType {
         match val {
-            ffi::VACCEL_TFLITE_NOTYPE => Type::NoType,
-            ffi::VACCEL_TFLITE_FLOAT32 => Type::Float32,
-            ffi::VACCEL_TFLITE_INT32 => Type::Int32,
-            ffi::VACCEL_TFLITE_UINT8 => Type::UInt8,
-            ffi::VACCEL_TFLITE_INT64 => Type::Int64,
-            ffi::VACCEL_TFLITE_STRING => Type::String,
-            ffi::VACCEL_TFLITE_BOOL => Type::Bool,
-            ffi::VACCEL_TFLITE_INT16 => Type::Int16,
-            ffi::VACCEL_TFLITE_COMPLEX64 => Type::Complex64,
-            ffi::VACCEL_TFLITE_INT8 => Type::Int8,
-            ffi::VACCEL_TFLITE_FLOAT16 => Type::Float16,
-            ffi::VACCEL_TFLITE_FLOAT64 => Type::Float64,
-            ffi::VACCEL_TFLITE_COMPLEX128 => Type::Complex128,
-            ffi::VACCEL_TFLITE_UINT64 => Type::UInt64,
-            ffi::VACCEL_TFLITE_RESOURCE => Type::Resource,
-            ffi::VACCEL_TFLITE_VARIANT => Type::Variant,
-            ffi::VACCEL_TFLITE_UINT32 => Type::UInt32,
-            ffi::VACCEL_TFLITE_UINT16 => Type::UInt16,
-            ffi::VACCEL_TFLITE_INT4 => Type::Int4,
-            unknown => Type::UnknownValue(unknown),
+            ffi::VACCEL_TFLITE_NOTYPE => DataType::NoType,
+            ffi::VACCEL_TFLITE_FLOAT32 => DataType::Float32,
+            ffi::VACCEL_TFLITE_INT32 => DataType::Int32,
+            ffi::VACCEL_TFLITE_UINT8 => DataType::UInt8,
+            ffi::VACCEL_TFLITE_INT64 => DataType::Int64,
+            ffi::VACCEL_TFLITE_STRING => DataType::String,
+            ffi::VACCEL_TFLITE_BOOL => DataType::Bool,
+            ffi::VACCEL_TFLITE_INT16 => DataType::Int16,
+            ffi::VACCEL_TFLITE_COMPLEX64 => DataType::Complex64,
+            ffi::VACCEL_TFLITE_INT8 => DataType::Int8,
+            ffi::VACCEL_TFLITE_FLOAT16 => DataType::Float16,
+            ffi::VACCEL_TFLITE_FLOAT64 => DataType::Float64,
+            ffi::VACCEL_TFLITE_COMPLEX128 => DataType::Complex128,
+            ffi::VACCEL_TFLITE_UINT64 => DataType::UInt64,
+            ffi::VACCEL_TFLITE_RESOURCE => DataType::Resource,
+            ffi::VACCEL_TFLITE_VARIANT => DataType::Variant,
+            ffi::VACCEL_TFLITE_UINT32 => DataType::UInt32,
+            ffi::VACCEL_TFLITE_UINT16 => DataType::UInt16,
+            ffi::VACCEL_TFLITE_INT4 => DataType::Int4,
+            unknown => DataType::UnknownValue(unknown),
         }
     }
 }

--- a/vaccel-bindings/src/ops/tensorflow/lite/status.rs
+++ b/vaccel-bindings/src/ops/tensorflow/lite/status.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{error::Status as ErrorStatus, Error, Result};
+use derive_more::{From, Into};
+use vaccel_rpc_proto::error::VaccelStatus;
+
+#[derive(Debug, Clone, Copy, PartialEq, Default, From, Into)]
+#[repr(transparent)]
+pub struct Status(pub u8);
+
+impl Status {
+    /// # Safety
+    ///
+    /// `ptr` is expected to be a valid pointer to an object allocated
+    /// manually or by the respective vAccel function.
+    pub unsafe fn populate_ffi(&self, ptr: *mut u8) {
+        if let Some(ffi) = unsafe { ptr.as_mut() } {
+            *ffi = (*self).into();
+        }
+    }
+}
+
+impl TryFrom<VaccelStatus> for Status {
+    type Error = Error;
+
+    fn try_from(status: VaccelStatus) -> Result<Self> {
+        Ok(Status(
+            status
+                .code
+                .try_into()
+                .map_err(|e| Error::ConversionFailed(format!("{}", e)))?,
+        ))
+    }
+}
+
+impl From<Status> for VaccelStatus {
+    fn from(status: Status) -> Self {
+        let mut vaccel_status = Self::new();
+        vaccel_status.code = u8::from(status) as u32;
+        vaccel_status
+    }
+}
+
+impl From<ErrorStatus> for Status {
+    fn from(status: ErrorStatus) -> Self {
+        Status(status.code)
+    }
+}
+
+impl From<&ErrorStatus> for Status {
+    fn from(status: &ErrorStatus) -> Self {
+        Status(status.code)
+    }
+}
+
+impl From<Status> for ErrorStatus {
+    fn from(status: Status) -> Self {
+        Self::new(status.into(), "")
+    }
+}

--- a/vaccel-bindings/src/ops/tensorflow/lite/tensor.rs
+++ b/vaccel-bindings/src/ops/tensorflow/lite/tensor.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{Code, Type as DataType};
+use super::DataType;
 use crate::{ffi, Error, Result};
 use protobuf::Enum;
 use std::ops::{Deref, DerefMut};
@@ -69,7 +69,7 @@ impl<T: TensorType> Tensor<T> {
             ) as u32
         } {
             ffi::VACCEL_OK => (),
-            err => return Err(Error::Runtime(err)),
+            err => return Err(Error::Ffi(err)),
         }
         assert!(!inner.is_null());
 
@@ -81,7 +81,7 @@ impl<T: TensorType> Tensor<T> {
             ) as u32
         } {
             ffi::VACCEL_OK => (),
-            err => return Err(Error::Runtime(err)),
+            err => return Err(Error::Ffi(err)),
         }
 
         Ok(Tensor {
@@ -98,18 +98,22 @@ impl<T: TensorType> Tensor<T> {
     /// manually or by the respective vAccel function.
     pub unsafe fn from_ffi(tensor: *mut ffi::vaccel_tflite_tensor) -> Result<Tensor<T>> {
         if tensor.is_null() {
-            return Err(Error::InvalidArgument);
+            return Err(Error::InvalidArgument(
+                "`tensor` cannot be `null`".to_string(),
+            ));
         }
 
         if DataType::from_int((*tensor).data_type) != T::data_type() {
-            return Err(Error::InvalidArgument);
+            return Err(Error::InvalidArgument(
+                "Invalid `tensor.data_type`".to_string(),
+            ));
         }
 
         let dims = std::slice::from_raw_parts((*tensor).dims as *mut _, (*tensor).nr_dims as usize);
 
-        let data_count = product(dims)
-            .try_into()
-            .map_err(|e| Error::Others(format!("{e}")))?;
+        let data_count = product(dims).try_into().map_err(|e| {
+            Error::ConversionFailed(format!("Could not convert `data_count` to `usize` [{}]", e))
+        })?;
 
         let data = if (*tensor).data.is_null() {
             let mut data = Vec::with_capacity(data_count);
@@ -129,7 +133,10 @@ impl<T: TensorType> Tensor<T> {
 
     pub fn with_data(mut self, data: &[T]) -> Result<Self> {
         if data.len() != self.data_count {
-            return Err(Error::InvalidArgument);
+            return Err(Error::InvalidArgument(format!(
+                "'data` length must be {}",
+                self.data_count
+            )));
         }
 
         for (e, v) in self.iter_mut().zip(data) {
@@ -145,7 +152,7 @@ impl<T: TensorType> Tensor<T> {
 
     pub fn dim(&self, idx: usize) -> Result<i32> {
         if idx >= self.dims.len() {
-            return Err(Error::TensorFlowLite(Code::Error));
+            return Err(Error::OutOfBounds);
         }
 
         Ok(self.dims[idx])
@@ -216,7 +223,7 @@ impl TensorAny for TFLiteTensor {
             ) as u32
         } {
             ffi::VACCEL_OK => (),
-            err => return Err(Error::Runtime(err)),
+            err => return Err(Error::Ffi(err)),
         }
         assert!(!inner.is_null());
 
@@ -228,7 +235,7 @@ impl TensorAny for TFLiteTensor {
                 as u32
         } {
             ffi::VACCEL_OK => (),
-            err => return Err(Error::Runtime(err)),
+            err => return Err(Error::Ffi(err)),
         }
 
         std::mem::forget(data);
@@ -247,7 +254,7 @@ impl TensorAny for TFLiteTensor {
             ) as u32
         } {
             ffi::VACCEL_OK => (),
-            err => return Err(Error::Runtime(err)),
+            err => return Err(Error::Ffi(err)),
         }
         assert!(!inner.is_null());
 
@@ -259,7 +266,7 @@ impl TensorAny for TFLiteTensor {
                 as u32
         } {
             ffi::VACCEL_OK => (),
-            err => return Err(Error::Runtime(err)),
+            err => return Err(Error::Ffi(err)),
         }
 
         std::mem::forget(data);

--- a/vaccel-bindings/src/ops/tensorflow/mod.rs
+++ b/vaccel-bindings/src/ops/tensorflow/mod.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::ffi;
-use std::{ffi::CStr, fmt};
 
 pub mod buffer;
 pub mod lite;
@@ -9,6 +8,7 @@ pub mod lite;
 pub mod model;
 #[cfg(target_pointer_width = "64")]
 pub mod node;
+pub mod status;
 #[cfg(target_pointer_width = "64")]
 pub mod tensor;
 
@@ -17,95 +17,9 @@ pub use buffer::Buffer;
 pub use model::{InferenceArgs, InferenceResult, Model};
 #[cfg(target_pointer_width = "64")]
 pub use node::Node;
+pub use status::Status;
 #[cfg(target_pointer_width = "64")]
 pub use tensor::{Tensor, TensorAny, TensorType};
-
-#[derive(Debug)]
-pub enum Code {
-    Ok = 0,
-    Cancelled,
-    Unknown,
-    InvalidArgument,
-    DeadlineExceeded,
-    NotFound,
-    AlreadyExists,
-    PermissionDenied,
-    ResourceExhausted,
-    FailedPrecondition,
-    Aborted,
-    OutOfRange,
-    Unimplemented,
-    Internal,
-    Unavailable,
-    DataLoss,
-    Unauthenticated,
-}
-
-impl Code {
-    pub(crate) fn to_u8(&self) -> u8 {
-        match self {
-            Code::Ok => 0,
-            Code::Cancelled => 1,
-            Code::Unknown => 2,
-            Code::InvalidArgument => 3,
-            Code::DeadlineExceeded => 4,
-            Code::NotFound => 5,
-            Code::AlreadyExists => 6,
-            Code::PermissionDenied => 7,
-            Code::ResourceExhausted => 8,
-            Code::FailedPrecondition => 9,
-            Code::Aborted => 10,
-            Code::OutOfRange => 11,
-            Code::Unimplemented => 12,
-            Code::Internal => 13,
-            Code::Unavailable => 14,
-            Code::DataLoss => 15,
-            Code::Unauthenticated => 16,
-        }
-    }
-}
-
-#[derive(Default)]
-pub struct Status {
-    inner: ffi::vaccel_tf_status,
-}
-
-impl Status {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn error_code(&self) -> u8 {
-        self.inner.error_code
-    }
-
-    pub fn message(&self) -> String {
-        if self.inner.message.is_null() {
-            return String::new();
-        }
-
-        let cmsg = unsafe { CStr::from_ptr(self.inner.message) };
-        cmsg.to_str().unwrap_or("").to_owned()
-    }
-
-    pub fn is_ok(&self) -> bool {
-        self.error_code() == Code::Ok.to_u8()
-    }
-
-    pub(crate) fn inner(&self) -> &ffi::vaccel_tf_status {
-        &self.inner
-    }
-
-    pub(crate) fn inner_mut(&mut self) -> &mut ffi::vaccel_tf_status {
-        &mut self.inner
-    }
-}
-
-impl fmt::Display for Status {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} (id:{})", self.message(), self.error_code())
-    }
-}
 
 #[derive(Debug, PartialEq, Default)]
 pub enum DataType {

--- a/vaccel-bindings/src/ops/tensorflow/status.rs
+++ b/vaccel-bindings/src/ops/tensorflow/status.rs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{error::Status as ErrorStatus, ffi, Error, Result};
+use derive_more::Display;
+use std::ffi::{CStr, CString};
+use vaccel_rpc_proto::error::VaccelStatus;
+
+#[derive(Debug, Default, Display)]
+#[display("{} ({})", self.message(), self.error_code())]
+pub struct Status {
+    inner: ffi::vaccel_tf_status,
+}
+
+impl Status {
+    pub fn new(error_code: u8, message: &str) -> Result<Self> {
+        let mut inner = ffi::vaccel_tf_status::default();
+        let c_message = CString::new(message).map_err(|e| {
+            Error::ConversionFailed(format!("Could not convert `message` to `CString` [{}]", e))
+        })?;
+
+        match unsafe {
+            ffi::vaccel_tf_status_init(&mut inner, error_code, c_message.as_c_str().as_ptr()) as u32
+        } {
+            ffi::VACCEL_OK => Ok(Self { inner }),
+            err => Err(Error::Ffi(err)),
+        }
+    }
+
+    pub fn error_code(&self) -> u8 {
+        self.inner.error_code
+    }
+
+    pub fn message(&self) -> String {
+        if self.inner.message.is_null() {
+            return String::new();
+        }
+
+        let c_message = unsafe { CStr::from_ptr(self.inner.message) };
+        c_message.to_str().unwrap_or("").to_owned()
+    }
+
+    /// # Safety
+    ///
+    /// `ptr` is expected to be a valid pointer to an object allocated
+    /// manually or by the respective vAccel function.
+    pub unsafe fn populate_ffi(&self, ptr: *mut ffi::vaccel_tf_status) {
+        if let Some(ffi) = unsafe { ptr.as_mut() } {
+            ffi.error_code = self.inner.error_code;
+            ffi.message = self.inner.message;
+        }
+    }
+
+    pub fn is_ok(&self) -> bool {
+        self.error_code() == 0
+    }
+
+    pub(crate) fn inner(&self) -> &ffi::vaccel_tf_status {
+        &self.inner
+    }
+
+    pub(crate) fn inner_mut(&mut self) -> &mut ffi::vaccel_tf_status {
+        &mut self.inner
+    }
+}
+
+impl TryFrom<VaccelStatus> for Status {
+    type Error = Error;
+
+    fn try_from(status: VaccelStatus) -> Result<Self> {
+        Self::new(
+            status.code.try_into().map_err(|e| {
+                Error::ConversionFailed(format!("Could not convert `status.code` to `u8` [{}]", e))
+            })?,
+            &status.message,
+        )
+    }
+}
+
+impl From<Status> for VaccelStatus {
+    fn from(status: Status) -> Self {
+        let mut vaccel_status = Self::new();
+        vaccel_status.code = status.error_code() as u32;
+        vaccel_status.message = status.message();
+        vaccel_status
+    }
+}
+
+impl TryFrom<ErrorStatus> for Status {
+    type Error = Error;
+
+    fn try_from(status: ErrorStatus) -> Result<Self> {
+        Self::new(status.code, &status.message)
+    }
+}
+
+impl TryFrom<&ErrorStatus> for Status {
+    type Error = Error;
+
+    fn try_from(status: &ErrorStatus) -> Result<Self> {
+        Self::new(status.code, &status.message)
+    }
+}
+
+impl From<Status> for ErrorStatus {
+    fn from(status: Status) -> Self {
+        Self::new(status.error_code(), &status.message())
+    }
+}

--- a/vaccel-bindings/src/ops/torch/buffer.rs
+++ b/vaccel-bindings/src/ops/torch/buffer.rs
@@ -16,7 +16,7 @@ impl Buffer {
             ffi::vaccel_torch_buffer_new(&mut inner, data.as_ptr() as *mut _, data.len()) as u32
         } {
             ffi::VACCEL_OK => (),
-            err => return Err(Error::Runtime(err)),
+            err => return Err(Error::Ffi(err)),
         }
         assert!(!inner.is_null());
         unsafe { assert!(!(*inner).data.is_null()) };
@@ -34,7 +34,9 @@ impl Buffer {
     /// manually or by the respective vAccel function.
     pub unsafe fn from_vaccel_buffer(buffer: *mut ffi::vaccel_torch_buffer) -> Result<Self> {
         if buffer.is_null() || (*buffer).data.is_null() || (*buffer).size == 0 {
-            return Err(Error::InvalidArgument);
+            return Err(Error::InvalidArgument(
+                "`buffer`, `buffer.data` and `buffer.size` cannot be `null`".to_string(),
+            ));
         }
 
         Ok(Buffer {

--- a/vaccel-bindings/src/ops/torch/mod.rs
+++ b/vaccel-bindings/src/ops/torch/mod.rs
@@ -10,51 +10,6 @@ pub use buffer::Buffer;
 pub use model::{InferenceArgs, InferenceResult, Model};
 pub use tensor::{Tensor, TensorAny, TensorType};
 
-#[derive(Debug)]
-pub enum Code {
-    Ok = 0,
-    Cancelled,
-    Unknown,
-    InvalidArgument,
-    DeadlineExceeded,
-    NotFound,
-    AlreadyExists,
-    PermissionDenied,
-    ResourceExhausted,
-    FailedPrecondition,
-    Aborted,
-    OutOfRange,
-    Unimplemented,
-    Internal,
-    Unavailable,
-    DataLoss,
-    Unauthenticated,
-}
-
-impl Code {
-    pub(crate) fn to_u8(&self) -> u8 {
-        match self {
-            Code::Ok => 0,
-            Code::Cancelled => 1,
-            Code::Unknown => 2,
-            Code::InvalidArgument => 3,
-            Code::DeadlineExceeded => 4,
-            Code::NotFound => 5,
-            Code::AlreadyExists => 6,
-            Code::PermissionDenied => 7,
-            Code::ResourceExhausted => 8,
-            Code::FailedPrecondition => 9,
-            Code::Aborted => 10,
-            Code::OutOfRange => 11,
-            Code::Unimplemented => 12,
-            Code::Internal => 13,
-            Code::Unavailable => 14,
-            Code::DataLoss => 15,
-            Code::Unauthenticated => 16,
-        }
-    }
-}
-
 #[derive(Debug, PartialEq, Default)]
 pub enum DataType {
     UInt8,

--- a/vaccel-bindings/src/profiling.rs
+++ b/vaccel-bindings/src/profiling.rs
@@ -9,7 +9,6 @@ use std::{
 };
 use vaccel_rpc_proto::profiling::{
     prof_region::Sample as ProtoSample, ProfRegion as ProtoProfRegion,
-    ProfRegions as ProtoProfRegions,
 };
 
 const NSEC_PER_SEC: u32 = 1_000_000_000;
@@ -315,11 +314,11 @@ impl From<&ProtoSample> for Sample {
     }
 }
 
-impl From<ProtoProfRegions> for ProfRegions {
-    fn from(arg: ProtoProfRegions) -> Self {
-        let mut t = ProfRegions::new("test");
+impl From<Vec<ProtoProfRegion>> for ProfRegions {
+    fn from(arg: Vec<ProtoProfRegion>) -> Self {
+        let mut t = ProfRegions::new("");
 
-        for pt in arg.timer.into_iter() {
+        for pt in arg.into_iter() {
             let s: Vec<Sample> = pt.samples.into_iter().map(|x| (&x).into()).collect();
             t.insert(&pt.name, s);
         }
@@ -336,7 +335,7 @@ impl From<&Sample> for ProtoSample {
     }
 }
 
-impl From<ProfRegions> for ProtoProfRegions {
+impl From<ProfRegions> for Vec<ProtoProfRegion> {
     fn from(arg: ProfRegions) -> Self {
         let mut pt: Vec<ProtoProfRegion> = Vec::new();
         for (n, t) in arg.iter() {
@@ -345,9 +344,7 @@ impl From<ProfRegions> for ProtoProfRegions {
             p.samples = t.iter().map(|x| x.into()).collect();
             pt.push(p);
         }
-        let mut t = ProtoProfRegions::new();
-        t.timer = pt;
-        t
+        pt
     }
 }
 

--- a/vaccel-bindings/src/session.rs
+++ b/vaccel-bindings/src/session.rs
@@ -30,7 +30,7 @@ impl Session {
 
         match unsafe { ffi::vaccel_session_init(&mut inner, flags) as u32 } {
             ffi::VACCEL_OK => Ok(Session { inner }),
-            err => Err(Error::Runtime(err)),
+            err => Err(Error::Ffi(err)),
         }
     }
 
@@ -59,7 +59,7 @@ impl Session {
 
         match unsafe { ffi::vaccel_session_release(&mut self.inner) as u32 } {
             ffi::VACCEL_OK => Ok(()),
-            err => Err(Error::Runtime(err)),
+            err => Err(Error::Ffi(err)),
         }
     }
 

--- a/vaccel-rpc-agent/Cargo.toml
+++ b/vaccel-rpc-agent/Cargo.toml
@@ -9,19 +9,21 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-vaccel-rpc-proto = { path = "../vaccel-rpc-proto" }
-vaccel = { path = "../vaccel-bindings" }
-ttrpc = { git = "https://github.com/nubificus/ttrpc-rust.git", branch = "vaccel-dev", features = ["async"] }
+async-trait = { version = "0.1", optional = true }
+clap = { version = "4.5", features = ["derive"] }
+ctrlc = { version = "3.4", features = ["termination"] }
+dashmap = { version = "6.0" }
 env_logger = "0.11"
 log = "0.4"
-ctrlc = { version = "3.4", features = ["termination"] }
-clap = { version = "4.5", features = ["derive"] }
-dashmap = { version = "6.0" }
-tokio = { version = "1.38", features = ["rt", "rt-multi-thread", "signal", "macros", "tracing"], optional = true }
-async-trait = { version = "0.1", optional = true }
+protobuf = "3.1"
 thiserror = "1.0"
+tokio = { version = "1.38", features = ["rt", "rt-multi-thread", "signal", "macros", "tracing"], optional = true }
+ttrpc = { git = "https://github.com/nubificus/ttrpc-rust.git", branch = "vaccel-dev", features = ["async"] }
 #tracing = "0.1"
 #tracing-subscriber = "0.3"
+
+vaccel = { path = "../vaccel-bindings" }
+vaccel-rpc-proto = { path = "../vaccel-rpc-proto" }
 
 [features]
 async = ["dep:async-trait", "dep:tokio"]

--- a/vaccel-rpc-agent/src/agent_service.rs
+++ b/vaccel-rpc-agent/src/agent_service.rs
@@ -1,9 +1,74 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use dashmap::DashMap;
-use std::{default::Default, pin::Pin, sync::Arc};
-use vaccel::{profiling::ProfRegions, Resource, Session, VaccelId};
-use vaccel_rpc_proto::profiling::{ProfilingRequest, ProfilingResponse};
+use protobuf::Message;
+use std::{pin::Pin, sync::Arc};
+use thiserror::Error as ThisError;
+use vaccel::{self, profiling::ProfRegions, Resource, Session, VaccelId};
+use vaccel_rpc_proto::{
+    error::{VaccelError, VaccelErrorType},
+    profiling::{ProfilingRequest, ProfilingResponse},
+};
+
+#[derive(ThisError, Debug)]
+pub enum AgentServiceError {
+    #[error("Invalid argument: {0}")]
+    InvalidArgument(String),
+
+    #[error("Object not founc: {0}")]
+    NotFound(String),
+
+    #[error("Internal error: {0}")]
+    Internal(String),
+
+    #[error("Vaccel error: {0}")]
+    Vaccel(#[from] vaccel::Error),
+}
+
+impl From<AgentServiceError> for ttrpc::Error {
+    fn from(e: AgentServiceError) -> Self {
+        match e {
+            AgentServiceError::InvalidArgument(s) => {
+                ttrpc::error::get_rpc_status(ttrpc::Code::INVALID_ARGUMENT, s.clone())
+            }
+            AgentServiceError::NotFound(s) => {
+                ttrpc::error::get_rpc_status(ttrpc::Code::NOT_FOUND, s.clone())
+            }
+            AgentServiceError::Internal(s) => {
+                ttrpc::error::get_rpc_status(ttrpc::Code::INTERNAL, s.clone())
+            }
+            AgentServiceError::Vaccel(e) => {
+                let mut status = ttrpc::error::get_status(ttrpc::Code::INTERNAL, e.to_string());
+
+                if let vaccel::Error::Runtime(ffi_error) = e {
+                    let mut err = VaccelError::new();
+                    err.type_ = VaccelErrorType::RUNTIME.into();
+                    err.ffi_error = ffi_error;
+
+                    let details = err.write_to_bytes().unwrap();
+                    let mut any = ttrpc::proto::Any::new();
+                    any.set_type_url("type.googleapis.com/vaccel.VaccelError".to_string());
+                    any.set_value(details);
+                    status.set_details(vec![any]);
+                }
+
+                ttrpc::Error::RpcStatus(status)
+            }
+        }
+    }
+}
+
+pub type Result<T> = std::result::Result<T, AgentServiceError>;
+
+pub trait IntoTtrpcResult<T> {
+    fn into_ttrpc(self) -> ttrpc::Result<T>;
+}
+
+impl<T> IntoTtrpcResult<T> for Result<T> {
+    fn into_ttrpc(self) -> ttrpc::Result<T> {
+        self.map_err(Into::into)
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct AgentService {
@@ -24,15 +89,15 @@ impl AgentService {
         }
     }
 
-    pub(crate) fn do_get_timers(&self, req: ProfilingRequest) -> ttrpc::Result<ProfilingResponse> {
+    pub(crate) fn do_get_timers(&self, req: ProfilingRequest) -> Result<ProfilingResponse> {
         let timers = self
             .timers
             .entry(req.session_id.into())
             .or_insert_with(|| ProfRegions::new("vaccel-agent"));
 
-        Ok(ProfilingResponse {
-            result: Some(timers.clone().into()).into(),
-            ..Default::default()
-        })
+        let mut resp = ProfilingResponse::new();
+        resp.timers = timers.clone().into();
+
+        Ok(resp)
     }
 }

--- a/vaccel-rpc-agent/src/asynchronous/agent_service.rs
+++ b/vaccel-rpc-agent/src/asynchronous/agent_service.rs
@@ -8,6 +8,7 @@ use vaccel_rpc_proto::tensorflow::{
     TensorflowLiteModelLoadRequest, TensorflowLiteModelRunRequest, TensorflowLiteModelRunResponse,
     TensorflowLiteModelUnloadRequest, TensorflowModelLoadRequest, TensorflowModelLoadResponse,
     TensorflowModelRunRequest, TensorflowModelRunResponse, TensorflowModelUnloadRequest,
+    TensorflowModelUnloadResponse,
 };
 use vaccel_rpc_proto::{
     asynchronous::agent_ttrpc,
@@ -88,7 +89,7 @@ impl agent_ttrpc::AgentService for AgentService {
         &self,
         _ctx: &::ttrpc::asynchronous::TtrpcContext,
         req: TensorflowModelUnloadRequest,
-    ) -> ttrpc::Result<Empty> {
+    ) -> ttrpc::Result<TensorflowModelUnloadResponse> {
         self.do_tensorflow_model_unload(req).into_ttrpc()
     }
 

--- a/vaccel-rpc-agent/src/asynchronous/agent_service.rs
+++ b/vaccel-rpc-agent/src/asynchronous/agent_service.rs
@@ -1,18 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::AgentService;
+use crate::{agent_service::IntoTtrpcResult, AgentService};
 use async_trait::async_trait;
 use std::default::Default;
 #[allow(unused_imports)]
 use vaccel_rpc_proto::tensorflow::{
-    TensorflowLiteModelLoadRequest, TensorflowLiteModelLoadResponse, TensorflowLiteModelRunRequest,
-    TensorflowLiteModelRunResponse, TensorflowLiteModelUnloadRequest,
-    TensorflowLiteModelUnloadResponse, TensorflowModelLoadRequest, TensorflowModelLoadResponse,
+    TensorflowLiteModelLoadRequest, TensorflowLiteModelRunRequest, TensorflowLiteModelRunResponse,
+    TensorflowLiteModelUnloadRequest, TensorflowModelLoadRequest, TensorflowModelLoadResponse,
     TensorflowModelRunRequest, TensorflowModelRunResponse, TensorflowModelUnloadRequest,
-    TensorflowModelUnloadResponse,
 };
 use vaccel_rpc_proto::{
-    asynchronous::{agent::EmptyResponse, agent_ttrpc},
+    asynchronous::agent_ttrpc,
+    empty::Empty,
     genop::{Arg, GenopRequest, GenopResponse},
     image::{ImageClassificationRequest, ImageClassificationResponse},
     profiling::{ProfilingRequest, ProfilingResponse},
@@ -32,23 +31,23 @@ impl agent_ttrpc::AgentService for AgentService {
         _ctx: &::ttrpc::asynchronous::TtrpcContext,
         req: CreateSessionRequest,
     ) -> ttrpc::Result<CreateSessionResponse> {
-        self.do_create_session(req)
+        self.do_create_session(req).into_ttrpc()
     }
 
     async fn update_session(
         &self,
         _ctx: &::ttrpc::asynchronous::TtrpcContext,
         req: UpdateSessionRequest,
-    ) -> ttrpc::Result<EmptyResponse> {
-        self.do_update_session(req)
+    ) -> ttrpc::Result<Empty> {
+        self.do_update_session(req).into_ttrpc()
     }
 
     async fn destroy_session(
         &self,
         _ctx: &::ttrpc::asynchronous::TtrpcContext,
         req: DestroySessionRequest,
-    ) -> ttrpc::Result<EmptyResponse> {
-        self.do_destroy_session(req)
+    ) -> ttrpc::Result<Empty> {
+        self.do_destroy_session(req).into_ttrpc()
     }
 
     async fn image_classification(
@@ -56,7 +55,7 @@ impl agent_ttrpc::AgentService for AgentService {
         _ctx: &::ttrpc::asynchronous::TtrpcContext,
         req: ImageClassificationRequest,
     ) -> ttrpc::Result<ImageClassificationResponse> {
-        self.do_image_classification(req)
+        self.do_image_classification(req).into_ttrpc()
     }
 
     async fn register_resource(
@@ -64,15 +63,15 @@ impl agent_ttrpc::AgentService for AgentService {
         _ctx: &::ttrpc::asynchronous::TtrpcContext,
         req: RegisterResourceRequest,
     ) -> ttrpc::Result<RegisterResourceResponse> {
-        self.do_register_resource(req)
+        self.do_register_resource(req).into_ttrpc()
     }
 
     async fn unregister_resource(
         &self,
         _ctx: &::ttrpc::asynchronous::TtrpcContext,
         req: UnregisterResourceRequest,
-    ) -> ttrpc::Result<EmptyResponse> {
-        self.do_unregister_resource(req)
+    ) -> ttrpc::Result<Empty> {
+        self.do_unregister_resource(req).into_ttrpc()
     }
 
     #[cfg(target_pointer_width = "64")]
@@ -81,7 +80,7 @@ impl agent_ttrpc::AgentService for AgentService {
         _ctx: &::ttrpc::asynchronous::TtrpcContext,
         req: TensorflowModelLoadRequest,
     ) -> ttrpc::Result<TensorflowModelLoadResponse> {
-        self.do_tensorflow_model_load(req)
+        self.do_tensorflow_model_load(req).into_ttrpc()
     }
 
     #[cfg(target_pointer_width = "64")]
@@ -89,8 +88,8 @@ impl agent_ttrpc::AgentService for AgentService {
         &self,
         _ctx: &::ttrpc::asynchronous::TtrpcContext,
         req: TensorflowModelUnloadRequest,
-    ) -> ttrpc::Result<TensorflowModelUnloadResponse> {
-        self.do_tensorflow_model_unload(req)
+    ) -> ttrpc::Result<Empty> {
+        self.do_tensorflow_model_unload(req).into_ttrpc()
     }
 
     #[cfg(target_pointer_width = "64")]
@@ -99,23 +98,23 @@ impl agent_ttrpc::AgentService for AgentService {
         _ctx: &::ttrpc::asynchronous::TtrpcContext,
         req: TensorflowModelRunRequest,
     ) -> ttrpc::Result<TensorflowModelRunResponse> {
-        self.do_tensorflow_model_run(req)
+        self.do_tensorflow_model_run(req).into_ttrpc()
     }
 
     async fn tensorflow_lite_model_load(
         &self,
         _ctx: &::ttrpc::asynchronous::TtrpcContext,
         req: TensorflowLiteModelLoadRequest,
-    ) -> ttrpc::Result<TensorflowLiteModelLoadResponse> {
-        self.do_tflite_model_load(req)
+    ) -> ttrpc::Result<Empty> {
+        self.do_tflite_model_load(req).into_ttrpc()
     }
 
     async fn tensorflow_lite_model_unload(
         &self,
         _ctx: &::ttrpc::asynchronous::TtrpcContext,
         req: TensorflowLiteModelUnloadRequest,
-    ) -> ttrpc::Result<TensorflowLiteModelUnloadResponse> {
-        self.do_tflite_model_unload(req)
+    ) -> ttrpc::Result<Empty> {
+        self.do_tflite_model_unload(req).into_ttrpc()
     }
 
     async fn tensorflow_lite_model_run(
@@ -123,7 +122,7 @@ impl agent_ttrpc::AgentService for AgentService {
         _ctx: &::ttrpc::asynchronous::TtrpcContext,
         req: TensorflowLiteModelRunRequest,
     ) -> ttrpc::Result<TensorflowLiteModelRunResponse> {
-        self.do_tflite_model_run(req)
+        self.do_tflite_model_run(req).into_ttrpc()
     }
 
     async fn torch_jitload_forward(
@@ -131,7 +130,7 @@ impl agent_ttrpc::AgentService for AgentService {
         _ctx: &::ttrpc::asynchronous::TtrpcContext,
         req: TorchJitloadForwardRequest,
     ) -> ttrpc::Result<TorchJitloadForwardResponse> {
-        self.do_torch_jitload_forward(req)
+        self.do_torch_jitload_forward(req).into_ttrpc()
     }
 
     async fn genop(
@@ -139,7 +138,7 @@ impl agent_ttrpc::AgentService for AgentService {
         _ctx: &::ttrpc::asynchronous::TtrpcContext,
         req: GenopRequest,
     ) -> ttrpc::Result<GenopResponse> {
-        self.do_genop(req)
+        self.do_genop(req).into_ttrpc()
     }
 
     async fn genop_stream(
@@ -177,7 +176,7 @@ impl agent_ttrpc::AgentService for AgentService {
         }
 
         debug!("Genop is streaming");
-        self.do_genop(req)
+        self.do_genop(req).into_ttrpc()
     }
 
     async fn get_timers(
@@ -185,6 +184,6 @@ impl agent_ttrpc::AgentService for AgentService {
         _ctx: &::ttrpc::asynchronous::TtrpcContext,
         req: ProfilingRequest,
     ) -> ttrpc::Result<ProfilingResponse> {
-        self.do_get_timers(req)
+        self.do_get_timers(req).into_ttrpc()
     }
 }

--- a/vaccel-rpc-agent/src/cli.rs
+++ b/vaccel-rpc-agent/src/cli.rs
@@ -42,29 +42,35 @@ impl FromStr for VaccelConfig {
             let mut kv = part.splitn(2, '=');
             let key = kv
                 .next()
-                .ok_or(Error::CliError("Missing key".to_string()))?;
+                .ok_or(Error::InvalidArgument("Missing key".to_string()))?;
             let value = kv
                 .next()
-                .ok_or(Error::CliError("Missing value".to_string()))?;
+                .ok_or(Error::InvalidArgument("Missing value".to_string()))?;
             match key {
                 "plugins" => plugins = Some(value.to_string()),
                 "log_level" => {
                     log_level = Some(value.parse::<u8>().map_err(|_| {
-                        Error::CliError(format!("Invalid integer for log_level: {}", value))
+                        Error::InvalidArgument(format!("Invalid integer `{}` for log_level", value))
                     })?)
                 }
                 "log_file" => log_file = Some(value.to_string()),
                 "profiling_enabled" => {
                     profiling_enabled = Some(value.parse::<bool>().map_err(|_| {
-                        Error::CliError(format!("Invalid boolean for profiling_enabled: {}", value))
+                        Error::InvalidArgument(format!(
+                            "Invalid boolean `{}` for profiling_enabled",
+                            value
+                        ))
                     })?)
                 }
                 "version_ignore" => {
                     version_ignore = Some(value.parse::<bool>().map_err(|_| {
-                        Error::CliError(format!("Invalid boolean for version_ignore: {}", value))
+                        Error::InvalidArgument(format!(
+                            "Invalid boolean `{}` for version_ignore",
+                            value
+                        ))
                     })?)
                 }
-                _ => return Err(Error::CliError(format!("Unknown key: {}", key))),
+                _ => return Err(Error::InvalidArgument(format!("Unknown key `{}`", key))),
             }
         }
 

--- a/vaccel-rpc-agent/src/lib.rs
+++ b/vaccel-rpc-agent/src/lib.rs
@@ -25,7 +25,7 @@ pub enum Error {
 
     /// vAccel runtime error
     #[error("vAccel error: {0}")]
-    RuntimeError(String),
+    VaccelError(vaccel::Error),
 
     /// Socket error
     #[error("ttrpc error: {0}")]
@@ -42,7 +42,7 @@ pub enum Error {
 
 impl From<vaccel::Error> for Error {
     fn from(err: vaccel::Error) -> Self {
-        Error::RuntimeError(format!("{}", err))
+        Error::VaccelError(err)
     }
 }
 

--- a/vaccel-rpc-agent/src/lib.rs
+++ b/vaccel-rpc-agent/src/lib.rs
@@ -19,37 +19,29 @@ pub use cli::Cli;
 
 #[derive(ThisError, Debug)]
 pub enum Error {
-    /// Agent error
-    #[error("Agent error: {0}")]
-    AgentError(String),
-
-    /// vAccel runtime error
     #[error("vAccel error: {0}")]
-    VaccelError(vaccel::Error),
+    Vaccel(#[from] vaccel::Error),
 
-    /// Socket error
     #[error("ttrpc error: {0}")]
-    TtrpcError(ttrpc::Error),
+    Ttrpc(#[from] ttrpc::Error),
 
-    /// CLI error
-    #[error("CLI error: {0}")]
-    CliError(String),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
 
-    /// Undefined error
-    #[error("Undefined error")]
-    Undefined,
-}
+    #[error("Invalid argument: {0}")]
+    InvalidArgument(String),
 
-impl From<vaccel::Error> for Error {
-    fn from(err: vaccel::Error) -> Self {
-        Error::VaccelError(err)
-    }
-}
+    #[error("Agent not running")]
+    NotRunning,
 
-impl From<ttrpc::Error> for Error {
-    fn from(err: ttrpc::Error) -> Self {
-        Error::TtrpcError(err)
-    }
+    #[error("Agent already running")]
+    AlreadyRunning,
+
+    #[error("Unsupported operation: {0}")]
+    Unsupported(String),
+
+    #[error("Error: {0}")]
+    Other(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/vaccel-rpc-agent/src/ops/image.rs
+++ b/vaccel-rpc-agent/src/ops/image.rs
@@ -1,32 +1,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ttrpc_error, AgentService};
-use log::{error, info};
+use crate::agent_service::{AgentService, AgentServiceError, Result};
+use log::info;
 use vaccel_rpc_proto::image::{ImageClassificationRequest, ImageClassificationResponse};
 
 impl AgentService {
     pub(crate) fn do_image_classification(
         &self,
         req: ImageClassificationRequest,
-    ) -> ttrpc::Result<ImageClassificationResponse> {
+    ) -> Result<ImageClassificationResponse> {
         let mut sess = self
             .sessions
             .get_mut(&req.session_id.into())
             .ok_or_else(|| {
-                ttrpc_error(ttrpc::Code::INVALID_ARGUMENT, "Unknown Session".to_string())
+                AgentServiceError::NotFound(
+                    format!("Unknown session {}", &req.session_id).to_string(),
+                )
             })?;
 
-        info!("session:{:?} Image classification", sess.id());
-        match sess.image_classification(&req.image) {
-            Err(e) => {
-                error!("Could not perform classification");
-                Err(ttrpc_error(ttrpc::Code::INTERNAL, e.to_string()))
-            }
-            Ok((tags, _)) => {
-                let mut resp = ImageClassificationResponse::new();
-                resp.tags = tags;
-                Ok(resp)
-            }
-        }
+        info!("session:{} Image classification", sess.id());
+        let (tags, _) = sess.image_classification(&req.image)?;
+
+        let mut resp = ImageClassificationResponse::new();
+        resp.tags = tags;
+
+        Ok(resp)
     }
 }

--- a/vaccel-rpc-agent/src/ops/tf.rs
+++ b/vaccel-rpc-agent/src/ops/tf.rs
@@ -1,26 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ttrpc_error, vaccel_error, AgentService};
-use log::debug;
+use crate::agent_service::{AgentService, AgentServiceError, Result};
+use log::{debug, info};
 use vaccel::ops::{tensorflow as tf, ModelInitialize, ModelLoadUnload, ModelRun};
-use vaccel_rpc_proto::tensorflow::{
-    InferenceResult as ProtoInferenceResult, TFTensor, TensorflowModelLoadRequest,
-    TensorflowModelLoadResponse, TensorflowModelRunRequest, TensorflowModelRunResponse,
-    TensorflowModelUnloadRequest, TensorflowModelUnloadResponse,
+use vaccel_rpc_proto::{
+    empty::Empty,
+    tensorflow::{
+        TFTensor, TensorflowModelLoadRequest, TensorflowModelLoadResponse,
+        TensorflowModelRunRequest, TensorflowModelRunResponse, TensorflowModelUnloadRequest,
+    },
 };
 
 impl AgentService {
     pub(crate) fn do_tensorflow_model_load(
         &self,
         req: TensorflowModelLoadRequest,
-    ) -> ttrpc::Result<TensorflowModelLoadResponse> {
+    ) -> Result<TensorflowModelLoadResponse> {
         let mut res = self
             .resources
             .get_mut(&req.model_id.into())
             .ok_or_else(|| {
-                ttrpc_error(
-                    ttrpc::Code::INVALID_ARGUMENT,
-                    "Unknown TensorFlow model".to_string(),
+                AgentServiceError::NotFound(
+                    format!("Unknown TensorFlow model {}", &req.model_id).to_string(),
                 )
             })?;
 
@@ -28,15 +29,18 @@ impl AgentService {
             .sessions
             .get_mut(&req.session_id.into())
             .ok_or_else(|| {
-                ttrpc_error(ttrpc::Code::INVALID_ARGUMENT, "Unknown session".to_string())
+                AgentServiceError::NotFound(
+                    format!("Unknown session {}", &req.session_id).to_string(),
+                )
             })?;
 
-        let mut resp = TensorflowModelLoadResponse::new();
+        info!("session:{} TensorFlow model load", sess.id());
         let mut model = tf::Model::new(res.as_mut());
-        match model.as_mut().load(&mut sess) {
-            Ok(_) => resp.set_graph_def(Vec::new()),
-            Err(e) => resp.set_error(vaccel_error(e)),
-        };
+        model.as_mut().load(&mut sess)?;
+
+        let mut resp = TensorflowModelLoadResponse::new();
+        // FIXME: Either remove this or properly return graph_def
+        resp.graph_def = Vec::new();
 
         Ok(resp)
     }
@@ -44,14 +48,13 @@ impl AgentService {
     pub(crate) fn do_tensorflow_model_unload(
         &self,
         req: TensorflowModelUnloadRequest,
-    ) -> ttrpc::Result<TensorflowModelUnloadResponse> {
+    ) -> Result<Empty> {
         let mut res = self
             .resources
             .get_mut(&req.model_id.into())
             .ok_or_else(|| {
-                ttrpc_error(
-                    ttrpc::Code::INVALID_ARGUMENT,
-                    "Unknown TensorFlow model".to_string(),
+                AgentServiceError::NotFound(
+                    format!("Unknown TensorFlow model {}", &req.model_id).to_string(),
                 )
             })?;
 
@@ -59,33 +62,28 @@ impl AgentService {
             .sessions
             .get_mut(&req.session_id.into())
             .ok_or_else(|| {
-                ttrpc_error(
-                    ttrpc::Code::INVALID_ARGUMENT,
-                    "Unknown vAccel session".to_string(),
+                AgentServiceError::NotFound(
+                    format!("Unknown session {}", &req.session_id).to_string(),
                 )
             })?;
 
-        let mut resp = TensorflowModelUnloadResponse::new();
+        info!("session:{} TensorFlow model unload", sess.id());
         let mut model = tf::Model::new(res.as_mut());
-        match model.as_mut().unload(&mut sess) {
-            Ok(_) => resp.success = true,
-            Err(e) => resp.error = Some(vaccel_error(e)).into(),
-        };
+        model.as_mut().unload(&mut sess)?;
 
-        Ok(resp)
+        Ok(Empty::new())
     }
 
     pub(crate) fn do_tensorflow_model_run(
         &self,
         req: TensorflowModelRunRequest,
-    ) -> ttrpc::Result<TensorflowModelRunResponse> {
+    ) -> Result<TensorflowModelRunResponse> {
         let mut res = self
             .resources
             .get_mut(&req.model_id.into())
             .ok_or_else(|| {
-                ttrpc_error(
-                    ttrpc::Code::INVALID_ARGUMENT,
-                    "Unknown TensorFlow model".to_string(),
+                AgentServiceError::NotFound(
+                    format!("Unknown TensorFlow model {}", &req.model_id).to_string(),
                 )
             })?;
 
@@ -93,64 +91,49 @@ impl AgentService {
             .sessions
             .get_mut(&req.session_id.into())
             .ok_or_else(|| {
-                ttrpc_error(ttrpc::Code::INVALID_ARGUMENT, "Unknown session".to_string())
+                AgentServiceError::NotFound(
+                    format!("Unknown session {}", &req.session_id).to_string(),
+                )
             })?;
-
-        let mut resp = TensorflowModelRunResponse::new();
 
         let mut sess_args = tf::InferenceArgs::new();
 
-        let run_options = match tf::Buffer::new(req.run_options.as_slice()) {
-            Ok(b) => b,
-            Err(e) => {
-                resp.set_error(vaccel_error(e));
-                return Ok(resp);
-            }
-        };
+        let run_options = tf::Buffer::new(req.run_options.as_slice())?;
         sess_args.set_run_options(&run_options);
 
-        let in_nodes: Vec<tf::Node> = match req.in_nodes.iter().map(|e| e.try_into()).collect() {
-            Ok(n) => n,
-            Err(e) => {
-                resp.set_error(vaccel_error(e));
-                return Ok(resp);
-            }
-        };
+        let in_nodes: Vec<tf::Node> = req
+            .in_nodes
+            .iter()
+            .map(|e| e.try_into())
+            .collect::<vaccel::Result<Vec<tf::Node>>>()?;
         let in_tensors = req.in_tensors;
         for it in in_nodes.iter().zip(in_tensors.iter()) {
             let (node, tensor) = it;
             debug!("tensor.dim: {:?}", tensor.dims);
-            if let Err(e) = sess_args.add_input(node, tensor) {
-                resp.set_error(vaccel_error(e));
-                return Ok(resp);
-            };
+            sess_args.add_input(node, tensor)?;
         }
 
-        let out_nodes: Vec<tf::Node> = match req.out_nodes.iter().map(|e| e.try_into()).collect() {
-            Ok(n) => n,
-            Err(e) => {
-                resp.set_error(vaccel_error(e));
-                return Ok(resp);
-            }
-        };
+        let out_nodes: Vec<tf::Node> = req
+            .out_nodes
+            .iter()
+            .map(|e| e.try_into())
+            .collect::<vaccel::Result<Vec<tf::Node>>>()?;
         let num_outputs = out_nodes.len();
         for output in out_nodes.iter() {
             sess_args.request_output(output);
         }
 
+        info!("session:{} TensorFlow model run", sess.id());
         let mut model = tf::Model::new(res.as_mut());
-        match model.as_mut().run(&mut sess, &mut sess_args) {
-            Ok(result) => {
-                let mut inference = ProtoInferenceResult::new();
-                let mut out_tensors: Vec<TFTensor> = Vec::with_capacity(num_outputs);
-                for i in 0..num_outputs {
-                    out_tensors.push(result.get_grpc_output(i).unwrap());
-                }
-                inference.out_tensors = out_tensors;
-                resp.set_result(inference);
-            }
-            Err(e) => resp.set_error(vaccel_error(e)),
-        };
+        let result = model.as_mut().run(&mut sess, &mut sess_args)?;
+
+        let mut out_tensors: Vec<TFTensor> = Vec::with_capacity(num_outputs);
+        for i in 0..num_outputs {
+            out_tensors.push(result.get_grpc_output(i)?);
+        }
+
+        let mut resp = TensorflowModelRunResponse::new();
+        resp.out_tensors = out_tensors;
 
         Ok(resp)
     }

--- a/vaccel-rpc-agent/src/ops/tflite.rs
+++ b/vaccel-rpc-agent/src/ops/tflite.rs
@@ -1,26 +1,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ttrpc_error, vaccel_error, AgentService};
-use log::debug;
+use crate::agent_service::{AgentService, AgentServiceError, Result};
+use log::{debug, info};
+use std::num::TryFromIntError;
 use vaccel::ops::{tensorflow::lite as tflite, ModelInitialize, ModelLoadUnload, ModelRun};
-use vaccel_rpc_proto::tensorflow::{
-    InferenceLiteResult, TFLiteTensor, TensorflowLiteModelLoadRequest,
-    TensorflowLiteModelLoadResponse, TensorflowLiteModelRunRequest, TensorflowLiteModelRunResponse,
-    TensorflowLiteModelUnloadRequest, TensorflowLiteModelUnloadResponse,
+use vaccel_rpc_proto::{
+    empty::Empty,
+    tensorflow::{
+        TFLiteTensor, TensorflowLiteModelLoadRequest, TensorflowLiteModelRunRequest,
+        TensorflowLiteModelRunResponse, TensorflowLiteModelUnloadRequest,
+    },
 };
 
 impl AgentService {
     pub(crate) fn do_tflite_model_load(
         &self,
         req: TensorflowLiteModelLoadRequest,
-    ) -> ttrpc::Result<TensorflowLiteModelLoadResponse> {
+    ) -> Result<Empty> {
         let mut res = self
             .resources
             .get_mut(&req.model_id.into())
             .ok_or_else(|| {
-                ttrpc_error(
-                    ttrpc::Code::INVALID_ARGUMENT,
-                    "Unknown TensorFlow Lite model".to_string(),
+                AgentServiceError::NotFound(
+                    format!("Unknown TensorFlow Lite model {}", &req.model_id).to_string(),
                 )
             })?;
 
@@ -28,29 +30,28 @@ impl AgentService {
             .sessions
             .get_mut(&req.session_id.into())
             .ok_or_else(|| {
-                ttrpc_error(ttrpc::Code::INVALID_ARGUMENT, "Unknown session".to_string())
+                AgentServiceError::NotFound(
+                    format!("Unknown session {}", &req.session_id).to_string(),
+                )
             })?;
 
-        let mut resp = TensorflowLiteModelLoadResponse::new();
+        info!("session:{} TensorFlow Lite model load", sess.id());
         let mut model = tflite::Model::new(res.as_mut());
-        if let Err(e) = model.as_mut().load(&mut sess) {
-            resp.set_error(vaccel_error(e));
-        };
+        model.as_mut().load(&mut sess)?;
 
-        Ok(resp)
+        Ok(Empty::new())
     }
 
     pub(crate) fn do_tflite_model_unload(
         &self,
         req: TensorflowLiteModelUnloadRequest,
-    ) -> ttrpc::Result<TensorflowLiteModelUnloadResponse> {
+    ) -> Result<Empty> {
         let mut res = self
             .resources
             .get_mut(&req.model_id.into())
             .ok_or_else(|| {
-                ttrpc_error(
-                    ttrpc::Code::INVALID_ARGUMENT,
-                    "Unknown TensorFlow Lite model".to_string(),
+                AgentServiceError::NotFound(
+                    format!("Unknown TensorFlow Lite model {}", &req.model_id).to_string(),
                 )
             })?;
 
@@ -58,32 +59,28 @@ impl AgentService {
             .sessions
             .get_mut(&req.session_id.into())
             .ok_or_else(|| {
-                ttrpc_error(
-                    ttrpc::Code::INVALID_ARGUMENT,
-                    "Unknown vAccel session".to_string(),
+                AgentServiceError::NotFound(
+                    format!("Unknown session {}", &req.session_id).to_string(),
                 )
             })?;
 
-        let mut resp = TensorflowLiteModelUnloadResponse::new();
+        info!("session:{} TensorFlow Lite model unload", sess.id());
         let mut model = tflite::Model::new(res.as_mut());
-        if let Err(e) = model.as_mut().unload(&mut sess) {
-            resp.set_error(vaccel_error(e));
-        };
+        model.as_mut().unload(&mut sess)?;
 
-        Ok(resp)
+        Ok(Empty::new())
     }
 
     pub(crate) fn do_tflite_model_run(
         &self,
         req: TensorflowLiteModelRunRequest,
-    ) -> ttrpc::Result<TensorflowLiteModelRunResponse> {
+    ) -> Result<TensorflowLiteModelRunResponse> {
         let mut res = self
             .resources
             .get_mut(&req.model_id.into())
             .ok_or_else(|| {
-                ttrpc_error(
-                    ttrpc::Code::INVALID_ARGUMENT,
-                    "Unknown TensorFlow Lite model".to_string(),
+                AgentServiceError::NotFound(
+                    format!("Unknown TensorFlow Lite model {}", &req.model_id).to_string(),
                 )
             })?;
 
@@ -91,38 +88,37 @@ impl AgentService {
             .sessions
             .get_mut(&req.session_id.into())
             .ok_or_else(|| {
-                ttrpc_error(ttrpc::Code::INVALID_ARGUMENT, "Unknown session".to_string())
+                AgentServiceError::NotFound(
+                    format!("Unknown session {}", &req.session_id).to_string(),
+                )
             })?;
-
-        let mut resp = TensorflowLiteModelRunResponse::new();
 
         let mut sess_args = tflite::InferenceArgs::new();
 
         let in_tensors = req.in_tensors;
         for tensor in in_tensors.iter() {
             debug!("tensor.dim: {:?}", tensor.dims);
-            if let Err(e) = sess_args.add_input(tensor) {
-                resp.set_error(vaccel_error(e));
-                return Ok(resp);
-            };
+            sess_args.add_input(tensor)?;
         }
 
         sess_args.set_nr_outputs(req.nr_outputs);
-        let num_outputs: usize = req.nr_outputs.try_into().unwrap();
+        let num_outputs: usize = req.nr_outputs.try_into().map_err(|e: TryFromIntError| {
+            AgentServiceError::Internal(
+                format!("Could not convert `nr_outputs` to usize: {}", e).to_string(),
+            )
+        })?;
 
+        info!("session:{} TensorFlow Lite model run", sess.id());
         let mut model = tflite::Model::new(res.as_mut());
-        match model.as_mut().run(&mut sess, &mut sess_args) {
-            Ok(result) => {
-                let mut inference = InferenceLiteResult::new();
-                let mut out_tensors: Vec<TFLiteTensor> = Vec::with_capacity(num_outputs);
-                for i in 0..num_outputs {
-                    out_tensors.push(result.get_grpc_output(i).unwrap());
-                }
-                inference.out_tensors = out_tensors;
-                resp.set_result(inference);
-            }
-            Err(e) => resp.set_error(vaccel_error(e)),
-        };
+        let result = model.as_mut().run(&mut sess, &mut sess_args)?;
+
+        let mut out_tensors: Vec<TFLiteTensor> = Vec::with_capacity(num_outputs);
+        for i in 0..num_outputs {
+            out_tensors.push(result.get_grpc_output(i)?);
+        }
+
+        let mut resp = TensorflowLiteModelRunResponse::new();
+        resp.out_tensors = out_tensors;
 
         Ok(resp)
     }

--- a/vaccel-rpc-agent/src/ops/tflite.rs
+++ b/vaccel-rpc-agent/src/ops/tflite.rs
@@ -119,6 +119,7 @@ impl AgentService {
 
         let mut resp = TensorflowLiteModelRunResponse::new();
         resp.out_tensors = out_tensors;
+        resp.status = Some(result.status.into()).into();
 
         Ok(resp)
     }

--- a/vaccel-rpc-agent/src/ops/torch.rs
+++ b/vaccel-rpc-agent/src/ops/torch.rs
@@ -1,23 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ttrpc_error, vaccel_error, AgentService};
+use crate::agent_service::{AgentService, AgentServiceError, Result};
+use log::info;
+use std::num::TryFromIntError;
 use vaccel::ops::{torch, ModelInitialize, ModelRun};
 use vaccel_rpc_proto::torch::{
-    TorchJitloadForwardRequest, TorchJitloadForwardResponse, TorchJitloadForwardResult, TorchTensor,
+    TorchJitloadForwardRequest, TorchJitloadForwardResponse, TorchTensor,
 };
 
 impl AgentService {
     pub(crate) fn do_torch_jitload_forward(
         &self,
         req: TorchJitloadForwardRequest,
-    ) -> ttrpc::Result<TorchJitloadForwardResponse> {
+    ) -> Result<TorchJitloadForwardResponse> {
         let mut res = self
             .resources
             .get_mut(&req.model_id.into())
             .ok_or_else(|| {
-                ttrpc_error(
-                    ttrpc::Code::INVALID_ARGUMENT,
-                    "Unknown PyTorch model".to_string(),
+                AgentServiceError::NotFound(
+                    format!("Unknown PyTorch model {}", &req.model_id).to_string(),
                 )
             })?;
 
@@ -25,46 +26,39 @@ impl AgentService {
             .sessions
             .get_mut(&req.session_id.into())
             .ok_or_else(|| {
-                ttrpc_error(ttrpc::Code::INVALID_ARGUMENT, "Unknown session".to_string())
+                AgentServiceError::NotFound(
+                    format!("Unknown session {}", &req.session_id).to_string(),
+                )
             })?;
-
-        let mut resp = TorchJitloadForwardResponse::new();
 
         let mut sess_args = torch::InferenceArgs::new();
 
-        let run_options = match torch::Buffer::new(req.run_options.as_slice()) {
-            Ok(b) => b,
-            Err(e) => {
-                resp.set_error(vaccel_error(e));
-                return Ok(resp);
-            }
-        };
+        let run_options = torch::Buffer::new(req.run_options.as_slice())?;
         sess_args.set_run_options(&run_options);
 
         let in_tensors = req.in_tensors;
         for tensor in in_tensors.iter() {
-            if let Err(e) = sess_args.add_input(tensor) {
-                resp.set_error(vaccel_error(e));
-                return Ok(resp);
-            };
+            sess_args.add_input(tensor)?;
         }
 
         sess_args.set_nr_outputs(req.nr_outputs);
-        let num_outputs: usize = req.nr_outputs.try_into().unwrap();
+        let num_outputs: usize = req.nr_outputs.try_into().map_err(|e: TryFromIntError| {
+            AgentServiceError::Internal(
+                format!("Could not convert `nr_outputs` to usize: {}", e).to_string(),
+            )
+        })?;
 
+        info!("session:{} PyTorch jitload forward", sess.id());
         let mut model = torch::Model::new(res.as_mut());
-        match model.as_mut().run(&mut sess, &mut sess_args) {
-            Ok(result) => {
-                let mut jitload_forward = TorchJitloadForwardResult::new();
-                let mut out_tensors: Vec<TorchTensor> = Vec::with_capacity(num_outputs);
-                for i in 0..num_outputs {
-                    out_tensors.push(result.get_grpc_output(i).unwrap());
-                }
-                jitload_forward.out_tensors = out_tensors;
-                resp.set_result(jitload_forward);
-            }
-            Err(e) => resp.set_error(vaccel_error(e)),
-        };
+        let result = model.as_mut().run(&mut sess, &mut sess_args)?;
+
+        let mut out_tensors: Vec<TorchTensor> = Vec::with_capacity(num_outputs);
+        for i in 0..num_outputs {
+            out_tensors.push(result.get_grpc_output(i)?);
+        }
+
+        let mut resp = TorchJitloadForwardResponse::new();
+        resp.out_tensors = out_tensors;
 
         Ok(resp)
     }

--- a/vaccel-rpc-agent/src/session.rs
+++ b/vaccel-rpc-agent/src/session.rs
@@ -1,74 +1,64 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ttrpc_error, AgentService};
+use crate::agent_service::{AgentService, AgentServiceError, Result};
 use dashmap::mapref::entry::Entry;
 use log::info;
-#[cfg(feature = "async")]
-use vaccel_rpc_proto::asynchronous::agent::EmptyResponse;
-use vaccel_rpc_proto::session::{
-    CreateSessionRequest, CreateSessionResponse, DestroySessionRequest, UpdateSessionRequest,
+use vaccel_rpc_proto::{
+    empty::Empty,
+    session::{
+        CreateSessionRequest, CreateSessionResponse, DestroySessionRequest, UpdateSessionRequest,
+    },
 };
-#[cfg(not(feature = "async"))]
-use vaccel_rpc_proto::sync::agent::EmptyResponse;
 
 impl AgentService {
     pub(crate) fn do_create_session(
         &self,
         req: CreateSessionRequest,
-    ) -> ttrpc::Result<CreateSessionResponse> {
-        match vaccel::Session::new(req.flags) {
-            Err(e) => Err(ttrpc_error(ttrpc::Code::INTERNAL, e.to_string())),
-            Ok(sess) => {
-                let mut resp = CreateSessionResponse::new();
-                resp.session_id = sess.id().into();
+    ) -> Result<CreateSessionResponse> {
+        let sess = vaccel::Session::new(req.flags)?;
 
-                let e = self.sessions.insert(sess.id(), Box::new(sess));
-                assert!(e.is_none());
+        let mut resp = CreateSessionResponse::new();
+        resp.session_id = sess.id().into();
 
-                info!("Created session {}", resp.session_id);
-                Ok(resp)
-            }
-        }
+        let e = self.sessions.insert(sess.id(), Box::new(sess));
+        assert!(e.is_none());
+
+        info!("Created session {}", resp.session_id);
+        Ok(resp)
     }
 
-    pub(crate) fn do_update_session(
-        &self,
-        req: UpdateSessionRequest,
-    ) -> ttrpc::Result<EmptyResponse> {
+    pub(crate) fn do_update_session(&self, req: UpdateSessionRequest) -> Result<Empty> {
         let mut sess = self
             .sessions
             .get_mut(&req.session_id.into())
-            .ok_or(ttrpc_error(
-                ttrpc::Code::INVALID_ARGUMENT,
-                "Unknown session".to_string(),
-            ))?;
+            .ok_or_else(|| {
+                AgentServiceError::NotFound(
+                    format!("Unknown session {}", &req.session_id).to_string(),
+                )
+            })?;
 
         info!("Updating hint {} for session {}", req.flags, req.session_id);
 
         sess.update(req.flags);
-        Ok(EmptyResponse::new())
+        Ok(Empty::new())
     }
 
-    pub(crate) fn do_destroy_session(
-        &self,
-        req: DestroySessionRequest,
-    ) -> ttrpc::Result<EmptyResponse> {
+    pub(crate) fn do_destroy_session(&self, req: DestroySessionRequest) -> Result<Empty> {
         let (_, mut sess) = self
             .sessions
             .remove(&req.session_id.into())
             .ok_or_else(|| {
-                ttrpc_error(ttrpc::Code::INVALID_ARGUMENT, "Unknown session".to_string())
+                AgentServiceError::NotFound(
+                    format!("Unknown session {}", &req.session_id).to_string(),
+                )
             })?;
 
         if let Entry::Occupied(t) = self.timers.entry(req.session_id.into()) {
             t.remove_entry();
         }
-        match sess.release() {
-            Err(e) => Err(ttrpc_error(ttrpc::Code::INTERNAL, e.to_string())),
-            Ok(()) => {
-                info!("Destroyed session {}", req.session_id);
-                Ok(EmptyResponse::new())
-            }
-        }
+        sess.release()?;
+
+        info!("Destroyed session {}", req.session_id);
+        Ok(Empty::new())
     }
 }

--- a/vaccel-rpc-agent/src/sync/agent_service.rs
+++ b/vaccel-rpc-agent/src/sync/agent_service.rs
@@ -6,6 +6,7 @@ use vaccel_rpc_proto::tensorflow::{
     TensorflowLiteModelLoadRequest, TensorflowLiteModelRunRequest, TensorflowLiteModelRunResponse,
     TensorflowLiteModelUnloadRequest, TensorflowModelLoadRequest, TensorflowModelLoadResponse,
     TensorflowModelRunRequest, TensorflowModelRunResponse, TensorflowModelUnloadRequest,
+    TensorflowModelUnloadResponse,
 };
 use vaccel_rpc_proto::{
     empty::Empty,
@@ -83,7 +84,7 @@ impl agent_ttrpc::AgentService for AgentService {
         &self,
         _ctx: &::ttrpc::sync::TtrpcContext,
         req: TensorflowModelUnloadRequest,
-    ) -> ttrpc::Result<Empty> {
+    ) -> ttrpc::Result<TensorflowModelUnloadResponse> {
         self.do_tensorflow_model_unload(req).into_ttrpc()
     }
 

--- a/vaccel-rpc-agent/src/sync/agent_service.rs
+++ b/vaccel-rpc-agent/src/sync/agent_service.rs
@@ -1,15 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::AgentService;
+use crate::{agent_service::IntoTtrpcResult, AgentService};
 #[allow(unused_imports)]
 use vaccel_rpc_proto::tensorflow::{
-    TensorflowLiteModelLoadRequest, TensorflowLiteModelLoadResponse, TensorflowLiteModelRunRequest,
-    TensorflowLiteModelRunResponse, TensorflowLiteModelUnloadRequest,
-    TensorflowLiteModelUnloadResponse, TensorflowModelLoadRequest, TensorflowModelLoadResponse,
+    TensorflowLiteModelLoadRequest, TensorflowLiteModelRunRequest, TensorflowLiteModelRunResponse,
+    TensorflowLiteModelUnloadRequest, TensorflowModelLoadRequest, TensorflowModelLoadResponse,
     TensorflowModelRunRequest, TensorflowModelRunResponse, TensorflowModelUnloadRequest,
-    TensorflowModelUnloadResponse,
 };
 use vaccel_rpc_proto::{
+    empty::Empty,
     genop::{GenopRequest, GenopResponse},
     image::{ImageClassificationRequest, ImageClassificationResponse},
     profiling::{ProfilingRequest, ProfilingResponse},
@@ -17,7 +16,7 @@ use vaccel_rpc_proto::{
     session::{
         CreateSessionRequest, CreateSessionResponse, DestroySessionRequest, UpdateSessionRequest,
     },
-    sync::{agent::EmptyResponse, agent_ttrpc},
+    sync::agent_ttrpc,
     torch::{TorchJitloadForwardRequest, TorchJitloadForwardResponse},
 };
 
@@ -27,23 +26,23 @@ impl agent_ttrpc::AgentService for AgentService {
         _ctx: &::ttrpc::sync::TtrpcContext,
         req: CreateSessionRequest,
     ) -> ttrpc::Result<CreateSessionResponse> {
-        self.do_create_session(req)
+        self.do_create_session(req).into_ttrpc()
     }
 
     fn update_session(
         &self,
         _ctx: &::ttrpc::TtrpcContext,
         req: UpdateSessionRequest,
-    ) -> ttrpc::Result<EmptyResponse> {
-        self.do_update_session(req)
+    ) -> ttrpc::Result<Empty> {
+        self.do_update_session(req).into_ttrpc()
     }
 
     fn destroy_session(
         &self,
         _ctx: &::ttrpc::sync::TtrpcContext,
         req: DestroySessionRequest,
-    ) -> ttrpc::Result<EmptyResponse> {
-        self.do_destroy_session(req)
+    ) -> ttrpc::Result<Empty> {
+        self.do_destroy_session(req).into_ttrpc()
     }
 
     fn image_classification(
@@ -51,7 +50,7 @@ impl agent_ttrpc::AgentService for AgentService {
         _ctx: &::ttrpc::sync::TtrpcContext,
         req: ImageClassificationRequest,
     ) -> ttrpc::Result<ImageClassificationResponse> {
-        self.do_image_classification(req)
+        self.do_image_classification(req).into_ttrpc()
     }
 
     fn register_resource(
@@ -59,15 +58,15 @@ impl agent_ttrpc::AgentService for AgentService {
         _ctx: &::ttrpc::sync::TtrpcContext,
         req: RegisterResourceRequest,
     ) -> ttrpc::Result<RegisterResourceResponse> {
-        self.do_register_resource(req)
+        self.do_register_resource(req).into_ttrpc()
     }
 
     fn unregister_resource(
         &self,
         _ctx: &::ttrpc::sync::TtrpcContext,
         req: UnregisterResourceRequest,
-    ) -> ttrpc::Result<EmptyResponse> {
-        self.do_unregister_resource(req)
+    ) -> ttrpc::Result<Empty> {
+        self.do_unregister_resource(req).into_ttrpc()
     }
 
     #[cfg(target_pointer_width = "64")]
@@ -76,7 +75,7 @@ impl agent_ttrpc::AgentService for AgentService {
         _ctx: &::ttrpc::sync::TtrpcContext,
         req: TensorflowModelLoadRequest,
     ) -> ttrpc::Result<TensorflowModelLoadResponse> {
-        self.do_tensorflow_model_load(req)
+        self.do_tensorflow_model_load(req).into_ttrpc()
     }
 
     #[cfg(target_pointer_width = "64")]
@@ -84,8 +83,8 @@ impl agent_ttrpc::AgentService for AgentService {
         &self,
         _ctx: &::ttrpc::sync::TtrpcContext,
         req: TensorflowModelUnloadRequest,
-    ) -> ttrpc::Result<TensorflowModelUnloadResponse> {
-        self.do_tensorflow_model_unload(req)
+    ) -> ttrpc::Result<Empty> {
+        self.do_tensorflow_model_unload(req).into_ttrpc()
     }
 
     #[cfg(target_pointer_width = "64")]
@@ -94,23 +93,23 @@ impl agent_ttrpc::AgentService for AgentService {
         _ctx: &::ttrpc::sync::TtrpcContext,
         req: TensorflowModelRunRequest,
     ) -> ttrpc::Result<TensorflowModelRunResponse> {
-        self.do_tensorflow_model_run(req)
+        self.do_tensorflow_model_run(req).into_ttrpc()
     }
 
     fn tensorflow_lite_model_load(
         &self,
         _ctx: &::ttrpc::sync::TtrpcContext,
         req: TensorflowLiteModelLoadRequest,
-    ) -> ttrpc::Result<TensorflowLiteModelLoadResponse> {
-        self.do_tflite_model_load(req)
+    ) -> ttrpc::Result<Empty> {
+        self.do_tflite_model_load(req).into_ttrpc()
     }
 
     fn tensorflow_lite_model_unload(
         &self,
         _ctx: &::ttrpc::sync::TtrpcContext,
         req: TensorflowLiteModelUnloadRequest,
-    ) -> ttrpc::Result<TensorflowLiteModelUnloadResponse> {
-        self.do_tflite_model_unload(req)
+    ) -> ttrpc::Result<Empty> {
+        self.do_tflite_model_unload(req).into_ttrpc()
     }
 
     fn tensorflow_lite_model_run(
@@ -118,7 +117,7 @@ impl agent_ttrpc::AgentService for AgentService {
         _ctx: &::ttrpc::sync::TtrpcContext,
         req: TensorflowLiteModelRunRequest,
     ) -> ttrpc::Result<TensorflowLiteModelRunResponse> {
-        self.do_tflite_model_run(req)
+        self.do_tflite_model_run(req).into_ttrpc()
     }
 
     fn torch_jitload_forward(
@@ -126,7 +125,7 @@ impl agent_ttrpc::AgentService for AgentService {
         _ctx: &::ttrpc::sync::TtrpcContext,
         req: TorchJitloadForwardRequest,
     ) -> ttrpc::Result<TorchJitloadForwardResponse> {
-        self.do_torch_jitload_forward(req)
+        self.do_torch_jitload_forward(req).into_ttrpc()
     }
 
     fn genop(
@@ -134,7 +133,7 @@ impl agent_ttrpc::AgentService for AgentService {
         _ctx: &::ttrpc::sync::TtrpcContext,
         req: GenopRequest,
     ) -> ttrpc::Result<GenopResponse> {
-        self.do_genop(req)
+        self.do_genop(req).into_ttrpc()
     }
 
     fn get_timers(
@@ -142,6 +141,6 @@ impl agent_ttrpc::AgentService for AgentService {
         _ctx: &::ttrpc::sync::TtrpcContext,
         req: ProfilingRequest,
     ) -> ttrpc::Result<ProfilingResponse> {
-        self.do_get_timers(req)
+        self.do_get_timers(req).into_ttrpc()
     }
 }

--- a/vaccel-rpc-client/Cargo.toml
+++ b/vaccel-rpc-client/Cargo.toml
@@ -11,17 +11,18 @@ license = "Apache-2.0"
 crate-type = ["staticlib"]
 
 [dependencies]
-vaccel-rpc-proto = { path = "../vaccel-rpc-proto" }
-vaccel = { path = "../vaccel-bindings" }
-ttrpc = { git = "https://github.com/nubificus/ttrpc-rust.git", branch = "vaccel-dev", features = ["async"] }
-protobuf = "3.1"
+dashmap = { version = "6.0" }
 env_logger = "0.11"
 log = "0.4"
+protobuf = "3.1"
 thiserror = "1.0"
-dashmap = { version = "6.0" }
 tokio = { version = "1.38", features = ["rt", "rt-multi-thread", "signal", "macros", "tracing"], optional = true }
+ttrpc = { git = "https://github.com/nubificus/ttrpc-rust.git", branch = "vaccel-dev", features = ["async"] }
 #tracing = "0.1"
 #tracing-subscriber = "0.3"
+
+vaccel = { path = "../vaccel-bindings" }
+vaccel-rpc-proto = { path = "../vaccel-rpc-proto" }
 
 [features]
 async = ["dep:tokio"]

--- a/vaccel-rpc-client/build.rs
+++ b/vaccel-rpc-client/build.rs
@@ -33,6 +33,7 @@ fn main() {
         .rename_item("vaccel_tf_buffer", "struct vaccel_tf_buffer")
         .rename_item("vaccel_tf_node", "struct vaccel_tf_node")
         .rename_item("vaccel_tf_tensor", "struct vaccel_tf_tensor")
+        .rename_item("vaccel_tf_status", "struct vaccel_tf_status")
         .rename_item("vaccel_tflite_tensor", "struct vaccel_tflite_tensor")
         .rename_item("vaccel_torch_buffer", "struct vaccel_torch_buffer")
         .rename_item("vaccel_torch_tensor", "struct vaccel_torch_tensor")

--- a/vaccel-rpc-client/src/asynchronous/ops/genop.rs
+++ b/vaccel-rpc-client/src/asynchronous/ops/genop.rs
@@ -94,7 +94,7 @@ impl VaccelRpcClient {
         self.timer_start(sess_id, "genop > client > ttrpc_client.genop");
         let tc = self.ttrpc_client.clone();
         let runtime = self.runtime.clone();
-        let mut resp = runtime.block_on(async {
+        let resp = runtime.block_on(async {
             self.timer_start(sess_id, "genop > client > ttrpc_client.genop > stream");
             let mut stream = tc.genop_stream(ctx).await.unwrap();
             self.timer_stop(sess_id, "genop > client > ttrpc_client.genop > stream");
@@ -111,10 +111,7 @@ impl VaccelRpcClient {
             res
         })?;
         self.timer_stop(sess_id, "genop > client > ttrpc_client.genop");
-        if resp.has_error() {
-            return Err(resp.take_error().into());
-        }
 
-        Ok(resp.take_result().write_args)
+        Ok(resp.write_args)
     }
 }

--- a/vaccel-rpc-client/src/lib.rs
+++ b/vaccel-rpc-client/src/lib.rs
@@ -2,8 +2,12 @@
 
 #![allow(dead_code)]
 
+use log::error;
+use protobuf::Message;
+use std::ffi::c_int;
 use thiserror::Error;
-use vaccel_rpc_proto::error::{vaccel_error::Error as VaccelErrorType, VaccelError};
+use vaccel::ffi;
+use vaccel_rpc_proto::error::{VaccelError, VaccelErrorType};
 
 #[cfg(feature = "async")]
 pub mod asynchronous;
@@ -44,7 +48,7 @@ pub enum Error {
 
     /// Agent error
     #[error("Agent error: {0}")]
-    AgentError(u32),
+    AgentError(String),
 
     /// Invalid argument error
     #[error("Invalid argument")]
@@ -53,6 +57,20 @@ pub enum Error {
     /// Undefined error
     #[error("Undefined error")]
     Undefined,
+
+    /// Other errors
+    #[error("Error: {0}")]
+    Others(String),
+}
+
+impl Error {
+    pub fn to_ffi(&self) -> u32 {
+        match self {
+            Error::HostRuntimeError(e) => *e,
+            Error::ClientError(_) => ffi::VACCEL_EBACKEND,
+            _ => ffi::VACCEL_EIO,
+        }
+    }
 }
 
 impl From<vaccel::Error> for Error {
@@ -63,6 +81,15 @@ impl From<vaccel::Error> for Error {
 
 impl From<ttrpc::Error> for Error {
     fn from(err: ttrpc::Error) -> Self {
+        if let ttrpc::Error::RpcStatus(ref rpc_status) = err {
+            let details = rpc_status.details();
+            if !details.is_empty() {
+                if let Ok(vaccel_error) = VaccelError::parse_from_bytes(details[0].value()) {
+                    return Error::HostRuntimeError(vaccel_error.ffi_error);
+                }
+            }
+        }
+
         Error::TtrpcError(err)
     }
 }
@@ -76,13 +103,53 @@ impl From<tokio::task::JoinError> for Error {
 
 impl From<vaccel_rpc_proto::error::VaccelError> for Error {
     fn from(err: VaccelError) -> Self {
-        match err.error {
-            Some(VaccelErrorType::VaccelError(err)) => Error::HostRuntimeError(err as u32),
-            Some(VaccelErrorType::AgentError(err)) => Error::AgentError(err as u32),
-            Some(_) => Error::Undefined,
-            None => Error::Undefined,
+        match err.type_.enum_value() {
+            Ok(VaccelErrorType::RUNTIME) => Error::HostRuntimeError(err.ffi_error),
+            Ok(_) => Error::Others(err.to_string()),
+            _ => Error::Undefined,
         }
     }
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+pub trait SealedFfiResult {}
+
+pub trait IntoFfiResult {
+    type FfiType;
+    fn into_ffi(self) -> Self::FfiType;
+}
+
+impl IntoFfiResult for Result<i64> {
+    type FfiType = ffi::vaccel_id_t;
+
+    fn into_ffi(self) -> Self::FfiType {
+        match self {
+            Ok(r) => r,
+            Err(e) => {
+                error!("{}", e);
+                -(e.to_ffi() as Self::FfiType)
+            }
+        }
+    }
+}
+
+impl<T> IntoFfiResult for Result<T>
+where
+    T: SealedFfiResult,
+{
+    type FfiType = c_int;
+
+    fn into_ffi(self) -> Self::FfiType {
+        (match self {
+            Ok(_) => ffi::VACCEL_OK,
+            Err(e) => {
+                error!("{}", e);
+                e.to_ffi()
+            }
+        }) as Self::FfiType
+    }
+}
+
+impl SealedFfiResult for () {}
+impl SealedFfiResult for Vec<u8> {}

--- a/vaccel-rpc-client/src/lib.rs
+++ b/vaccel-rpc-client/src/lib.rs
@@ -7,7 +7,7 @@ use protobuf::Message;
 use std::ffi::c_int;
 use thiserror::Error;
 use vaccel::ffi;
-use vaccel_rpc_proto::error::{VaccelError, VaccelErrorType};
+use vaccel_rpc_proto::error::VaccelError;
 
 #[cfg(feature = "async")]
 pub mod asynchronous;
@@ -36,15 +36,15 @@ pub enum Error {
     /// Async error
     #[cfg(feature = "async")]
     #[error("Async error: {0}")]
-    AsyncError(tokio::task::JoinError),
+    AsyncError(#[from] tokio::task::JoinError),
 
     /// vAccel error
     #[error("vAccel error: {0}")]
-    VaccelError(vaccel::Error),
+    VaccelError(#[from] vaccel::Error),
 
     /// Host vAccel runtime error
     #[error("Host vAccel error: {0}")]
-    HostRuntimeError(u32),
+    HostVaccelError(vaccel::Error),
 
     /// Agent error
     #[error("Agent error: {0}")]
@@ -66,16 +66,14 @@ pub enum Error {
 impl Error {
     pub fn to_ffi(&self) -> u32 {
         match self {
-            Error::HostRuntimeError(e) => *e,
+            Error::HostVaccelError(e) => match e {
+                vaccel::Error::Ffi(error) => *error,
+                vaccel::Error::FfiWithStatus { error, .. } => *error,
+                _ => ffi::VACCEL_EBACKEND,
+            },
             Error::ClientError(_) => ffi::VACCEL_EBACKEND,
             _ => ffi::VACCEL_EIO,
         }
-    }
-}
-
-impl From<vaccel::Error> for Error {
-    fn from(err: vaccel::Error) -> Self {
-        Error::VaccelError(err)
     }
 }
 
@@ -85,7 +83,7 @@ impl From<ttrpc::Error> for Error {
             let details = rpc_status.details();
             if !details.is_empty() {
                 if let Ok(vaccel_error) = VaccelError::parse_from_bytes(details[0].value()) {
-                    return Error::HostRuntimeError(vaccel_error.ffi_error);
+                    return Error::HostVaccelError(vaccel_error.into());
                 }
             }
         }
@@ -94,26 +92,12 @@ impl From<ttrpc::Error> for Error {
     }
 }
 
-#[cfg(feature = "async")]
-impl From<tokio::task::JoinError> for Error {
-    fn from(err: tokio::task::JoinError) -> Self {
-        Error::AsyncError(err)
-    }
-}
-
-impl From<vaccel_rpc_proto::error::VaccelError> for Error {
-    fn from(err: VaccelError) -> Self {
-        match err.type_.enum_value() {
-            Ok(VaccelErrorType::RUNTIME) => Error::HostRuntimeError(err.ffi_error),
-            Ok(_) => Error::Others(err.to_string()),
-            _ => Error::Undefined,
-        }
-    }
-}
-
 pub type Result<T> = std::result::Result<T, Error>;
 
 pub trait SealedFfiResult {}
+
+impl SealedFfiResult for () {}
+impl SealedFfiResult for Vec<u8> {}
 
 pub trait IntoFfiResult {
     type FfiType;
@@ -150,6 +134,3 @@ where
         }) as Self::FfiType
     }
 }
-
-impl SealedFfiResult for () {}
-impl SealedFfiResult for Vec<u8> {}

--- a/vaccel-rpc-client/src/ops/image.rs
+++ b/vaccel-rpc-client/src/ops/image.rs
@@ -4,7 +4,7 @@
 use crate::asynchronous::client::VaccelRpcClient;
 #[cfg(not(feature = "async"))]
 use crate::sync::client::VaccelRpcClient;
-use crate::{Error, Result};
+use crate::Result;
 use log::error;
 use std::{
     ffi::{c_int, c_uchar},
@@ -55,17 +55,14 @@ pub unsafe extern "C" fn vaccel_rpc_client_image_classify(
         None => return ffi::VACCEL_EINVAL as c_int,
     };
 
-    match client.image_classify(sess_id, img.to_vec()) {
+    (match client.image_classify(sess_id, img.to_vec()) {
         Ok(ret) => {
             tags_slice.copy_from_slice(&ret[..tags_slice.len()]);
-            ffi::VACCEL_OK as c_int
+            ffi::VACCEL_OK
         }
         Err(e) => {
             error!("{}", e);
-            match e {
-                Error::ClientError(_) => ffi::VACCEL_EBACKEND as c_int,
-                _ => ffi::VACCEL_EIO as c_int,
-            }
+            e.to_ffi()
         }
-    }
+    }) as c_int
 }

--- a/vaccel-rpc-client/src/ops/tf.rs
+++ b/vaccel-rpc-client/src/ops/tf.rs
@@ -4,21 +4,26 @@
 use crate::asynchronous::client::VaccelRpcClient;
 #[cfg(not(feature = "async"))]
 use crate::sync::client::VaccelRpcClient;
-use crate::{IntoFfiResult, Result};
+use crate::{Error, Result};
 use log::error;
 use std::ffi::c_int;
-use vaccel::{c_pointer_to_mut_slice, c_pointer_to_slice, ffi};
+use vaccel::{
+    c_pointer_to_mut_slice, c_pointer_to_slice, ffi, ops::tensorflow::Status as TfStatus,
+};
 #[cfg(feature = "async")]
 use vaccel_rpc_proto::asynchronous::agent_ttrpc::AgentServiceClient;
 #[cfg(not(feature = "async"))]
 use vaccel_rpc_proto::sync::agent_ttrpc::AgentServiceClient;
-use vaccel_rpc_proto::tensorflow::{
-    TFNode, TFTensor, TensorflowModelLoadRequest, TensorflowModelRunRequest,
-    TensorflowModelUnloadRequest,
+use vaccel_rpc_proto::{
+    error::VaccelStatus,
+    tensorflow::{
+        TFNode, TFTensor, TensorflowModelLoadRequest, TensorflowModelRunRequest,
+        TensorflowModelUnloadRequest,
+    },
 };
 
 impl VaccelRpcClient {
-    pub fn tf_model_load(&self, model_id: i64, session_id: i64) -> Result<Vec<u8>> {
+    pub fn tf_model_load(&self, model_id: i64, session_id: i64) -> Result<(Vec<u8>, TfStatus)> {
         let ctx = ttrpc::context::Context::default();
         let req = TensorflowModelLoadRequest {
             session_id,
@@ -28,10 +33,12 @@ impl VaccelRpcClient {
 
         let resp = self.execute(AgentServiceClient::tensorflow_model_load, ctx, &req)?;
 
-        Ok(resp.graph_def)
+        let status = resp.status.unwrap_or(VaccelStatus::default());
+
+        Ok((resp.graph_def, status.try_into()?))
     }
 
-    pub fn tf_model_unload(&self, model_id: i64, session_id: i64) -> Result<()> {
+    pub fn tf_model_unload(&self, model_id: i64, session_id: i64) -> Result<TfStatus> {
         let ctx = ttrpc::context::Context::default();
         let req = TensorflowModelUnloadRequest {
             session_id,
@@ -39,9 +46,9 @@ impl VaccelRpcClient {
             ..Default::default()
         };
 
-        self.execute(AgentServiceClient::tensorflow_model_unload, ctx, &req)?;
+        let resp = self.execute(AgentServiceClient::tensorflow_model_unload, ctx, &req)?;
 
-        Ok(())
+        Ok(resp.status.unwrap_or(VaccelStatus::default()).try_into()?)
     }
 
     pub fn tf_model_run(
@@ -52,7 +59,7 @@ impl VaccelRpcClient {
         in_nodes: Vec<TFNode>,
         in_tensors: Vec<TFTensor>,
         out_nodes: Vec<TFNode>,
-    ) -> Result<Vec<*mut ffi::vaccel_tf_tensor>> {
+    ) -> Result<(Vec<*mut ffi::vaccel_tf_tensor>, TfStatus)> {
         let ctx = ttrpc::context::Context::default();
 
         let req = TensorflowModelRunRequest {
@@ -67,7 +74,8 @@ impl VaccelRpcClient {
 
         let resp = self.execute(AgentServiceClient::tensorflow_model_run, ctx, &req)?;
 
-        resp.out_tensors
+        let out_tensors: Vec<*mut ffi::vaccel_tf_tensor> = resp
+            .out_tensors
             .into_iter()
             .map(|e| unsafe {
                 let dims = e.dims;
@@ -83,7 +91,7 @@ impl VaccelRpcClient {
                 ) as u32
                 {
                     ffi::VACCEL_OK => (),
-                    err => return Err(vaccel::Error::Runtime(err).into()),
+                    err => return Err(vaccel::Error::Ffi(err)),
                 }
 
                 match ffi::vaccel_tf_tensor_set_data(
@@ -93,14 +101,29 @@ impl VaccelRpcClient {
                 ) as u32
                 {
                     ffi::VACCEL_OK => (),
-                    err => return Err(vaccel::Error::Runtime(err).into()),
+                    err => return Err(vaccel::Error::Ffi(err)),
                 }
 
                 std::mem::forget(data);
 
                 Ok(tensor)
             })
-            .collect()
+            .collect::<vaccel::Result<Vec<*mut ffi::vaccel_tf_tensor>>>()?;
+        let status = resp.status.unwrap_or(VaccelStatus::default());
+
+        Ok((out_tensors, status.try_into()?))
+    }
+}
+
+impl Error {
+    fn to_tf_status(&self) -> TfStatus {
+        match self {
+            Error::HostVaccelError(ref e) => match e.get_status() {
+                Some(status) => TfStatus::try_from(status).unwrap_or_default(),
+                None => TfStatus::new(u8::MAX, "Undefined error").unwrap_or_default(),
+            },
+            err => TfStatus::new(u8::MAX, &err.to_string()).unwrap_or_default(),
+        }
     }
 }
 
@@ -113,13 +136,24 @@ pub unsafe extern "C" fn vaccel_rpc_client_tf_session_load(
     client_ptr: *const VaccelRpcClient,
     model_id: ffi::vaccel_id_t,
     sess_id: i64,
+    status_ptr: *mut ffi::vaccel_tf_status,
 ) -> c_int {
     let client = match unsafe { client_ptr.as_ref() } {
         Some(client) => client,
         None => return ffi::VACCEL_EINVAL as c_int,
     };
 
-    client.tf_model_load(model_id, sess_id).into_ffi()
+    (match client.tf_model_load(model_id, sess_id) {
+        Ok((_, status)) => {
+            status.populate_ffi(status_ptr);
+            ffi::VACCEL_OK
+        }
+        Err(e) => {
+            error!("{}", e);
+            e.to_tf_status().populate_ffi(status_ptr);
+            e.to_ffi()
+        }
+    }) as c_int
 }
 
 /// # Safety
@@ -131,13 +165,24 @@ pub unsafe extern "C" fn vaccel_rpc_client_tf_session_delete(
     client_ptr: *const VaccelRpcClient,
     model_id: ffi::vaccel_id_t,
     sess_id: i64,
+    status_ptr: *mut ffi::vaccel_tf_status,
 ) -> c_int {
     let client = match unsafe { client_ptr.as_ref() } {
         Some(client) => client,
         None => return ffi::VACCEL_EINVAL as c_int,
     };
 
-    client.tf_model_unload(model_id, sess_id).into_ffi()
+    (match client.tf_model_unload(model_id, sess_id) {
+        Ok(status) => {
+            status.populate_ffi(status_ptr);
+            ffi::VACCEL_OK
+        }
+        Err(e) => {
+            error!("{}", e);
+            e.to_tf_status().populate_ffi(status_ptr);
+            e.to_ffi()
+        }
+    }) as c_int
 }
 
 /// # Safety
@@ -159,6 +204,7 @@ pub unsafe extern "C" fn vaccel_rpc_client_tf_session_run(
     out_nodes_ptr: *const ffi::vaccel_tf_node,
     out_tensors_ptr: *mut *mut ffi::vaccel_tf_tensor,
     nr_outputs: c_int,
+    status_ptr: *mut ffi::vaccel_tf_status,
 ) -> c_int {
     let run_options = unsafe {
         c_pointer_to_slice((*run_options_ptr).data as *mut u8, (*run_options_ptr).size)
@@ -206,12 +252,14 @@ pub unsafe extern "C" fn vaccel_rpc_client_tf_session_run(
         in_tensors,
         out_nodes,
     ) {
-        Ok(result) => {
-            out_tensors.copy_from_slice(&result);
+        Ok((tensors, status)) => {
+            out_tensors.copy_from_slice(&tensors);
+            status.populate_ffi(status_ptr);
             ffi::VACCEL_OK
         }
         Err(e) => {
             error!("{}", e);
+            e.to_tf_status().populate_ffi(status_ptr);
             e.to_ffi()
         }
     }) as c_int

--- a/vaccel-rpc-client/src/ops/tf.rs
+++ b/vaccel-rpc-client/src/ops/tf.rs
@@ -118,7 +118,7 @@ impl VaccelRpcClient {
 impl Error {
     fn to_tf_status(&self) -> TfStatus {
         match self {
-            Error::HostVaccelError(ref e) => match e.get_status() {
+            Error::HostVaccel(ref e) => match e.get_status() {
                 Some(status) => TfStatus::try_from(status).unwrap_or_default(),
                 None => TfStatus::new(u8::MAX, "Undefined error").unwrap_or_default(),
             },

--- a/vaccel-rpc-client/src/ops/tflite.rs
+++ b/vaccel-rpc-client/src/ops/tflite.rs
@@ -112,7 +112,7 @@ impl VaccelRpcClient {
 impl Error {
     fn to_tflite_status(&self) -> TfliteStatus {
         match self {
-            Error::HostVaccelError(ref e) => match e.get_status() {
+            Error::HostVaccel(ref e) => match e.get_status() {
                 Some(status) => TfliteStatus::from(status),
                 None => TfliteStatus(u8::MAX),
             },

--- a/vaccel-rpc-client/src/ops/torch.rs
+++ b/vaccel-rpc-client/src/ops/torch.rs
@@ -104,7 +104,7 @@ pub unsafe extern "C" fn vaccel_rpc_client_torch_jitload_forward(
                     .iter()
                     .map(|e| unsafe {
                         e.as_ref()
-                            .ok_or(Error::InvalidArgument)?
+                            .ok_or(Error::InvalidArgument("".to_string()))?
                             .try_into()
                             .map_err(|e: vaccel::Error| e.into())
                     })
@@ -113,7 +113,7 @@ pub unsafe extern "C" fn vaccel_rpc_client_torch_jitload_forward(
                     Ok(s) => s,
                     Err(e) => {
                         return match e {
-                            Error::InvalidArgument => ffi::VACCEL_EINVAL,
+                            Error::InvalidArgument(_) => ffi::VACCEL_EINVAL,
                             _ => {
                                 error!("{}", e);
                                 ffi::VACCEL_EBACKEND

--- a/vaccel-rpc-client/src/ops/torch.rs
+++ b/vaccel-rpc-client/src/ops/torch.rs
@@ -52,7 +52,7 @@ impl VaccelRpcClient {
                 ) as u32
                 {
                     ffi::VACCEL_OK => (),
-                    err => return Err(vaccel::Error::Runtime(err).into()),
+                    err => return Err(vaccel::Error::Ffi(err).into()),
                 }
 
                 match ffi::vaccel_torch_tensor_set_data(
@@ -62,7 +62,7 @@ impl VaccelRpcClient {
                 ) as u32
                 {
                     ffi::VACCEL_OK => (),
-                    err => return Err(vaccel::Error::Runtime(err).into()),
+                    err => return Err(vaccel::Error::Ffi(err).into()),
                 }
 
                 std::mem::forget(data);

--- a/vaccel-rpc-client/src/profiling.rs
+++ b/vaccel-rpc-client/src/profiling.rs
@@ -4,7 +4,7 @@
 use crate::asynchronous::client::VaccelRpcClient;
 #[cfg(not(feature = "async"))]
 use crate::sync::client::VaccelRpcClient;
-use crate::{Error, Result};
+use crate::Result;
 use std::{collections::BTreeMap, ptr};
 use vaccel::{c_pointer_to_mut_slice, ffi, profiling::ProfRegions};
 #[cfg(feature = "async")]
@@ -62,12 +62,9 @@ impl VaccelRpcClient {
             ..Default::default()
         };
 
-        let mut resp = self.execute(AgentServiceClient::get_timers, ctx, &req)?;
+        let resp = self.execute(AgentServiceClient::get_timers, ctx, &req)?;
 
-        match resp.result.take() {
-            Some(r) => Ok(r.into()),
-            None => Err(Error::Undefined),
-        }
+        Ok(resp.timers.into())
     }
 }
 

--- a/vaccel-rpc-client/src/resource.rs
+++ b/vaccel-rpc-client/src/resource.rs
@@ -83,7 +83,7 @@ pub unsafe extern "C" fn vaccel_rpc_client_resource_register(
                 .map(|&p| {
                     Ok(CStr::from_ptr(p)
                         .to_str()
-                        .map_err(|_| Error::InvalidArgument)?
+                        .map_err(|_| Error::Unknown)?
                         .to_string())
                 })
                 .collect::<Result<Vec<String>>>()
@@ -105,9 +105,9 @@ pub unsafe extern "C" fn vaccel_rpc_client_resource_register(
             files = match f_slice
                 .iter()
                 .map(|&p| {
-                    let f = unsafe { p.as_ref().ok_or(Error::InvalidArgument)? };
+                    let f = unsafe { p.as_ref().ok_or(Error::Unknown)? };
 
-                    File::try_from(f).map_err(|_| Error::InvalidArgument)
+                    File::try_from(f).map_err(|_| Error::Unknown)
                 })
                 .collect::<Result<Vec<File>>>()
             {

--- a/vaccel-rpc-proto/Cargo.toml
+++ b/vaccel-rpc-proto/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-ttrpc = { git = "https://github.com/nubificus/ttrpc-rust.git", branch = "vaccel-dev", features = ["async"] }
-protobuf = "3.1"
 async-trait = "0.1"
+protobuf = "3.1"
+ttrpc = { git = "https://github.com/nubificus/ttrpc-rust.git", branch = "vaccel-dev", features = ["async"] }
 
 [build-dependencies]
 ttrpc-codegen = { git = "https://github.com/nubificus/ttrpc-rust.git", branch = "vaccel-dev" }

--- a/vaccel-rpc-proto/build.rs
+++ b/vaccel-rpc-proto/build.rs
@@ -130,7 +130,7 @@ fn main() {
         })
         .rust_protobuf_customize(protobuf_customized.clone())
         .run()
-        .expect("Async protocol generation failed.");
+        .expect("Common protocol generation failed.");
 
     Codegen::new()
         .out_dir(format!("{}/asynchronous", out_dir))

--- a/vaccel-rpc-proto/protos/async/agent.proto
+++ b/vaccel-rpc-proto/protos/async/agent.proto
@@ -2,42 +2,41 @@
 
 syntax = "proto3";
 
-import "session.proto";
-import "resource.proto";
+import "empty.proto";
+import "genop.proto";
 import "image.proto";
+import "profiling.proto";
+import "resource.proto";
+import "session.proto";
 import "tensorflow.proto";
 import "torch.proto";
-import "genop.proto";
-import "profiling.proto";
 
 package vaccel;
 
 service AgentService {
 	// Session handling
 	rpc CreateSession(CreateSessionRequest) returns (CreateSessionResponse);
-	rpc UpdateSession(UpdateSessionRequest) returns (EmptyResponse);
-	rpc DestroySession(DestroySessionRequest) returns (EmptyResponse);
+	rpc UpdateSession(UpdateSessionRequest) returns (Empty);
+	rpc DestroySession(DestroySessionRequest) returns (Empty);
 
 	// vAccel resource handling
 	rpc RegisterResource(RegisterResourceRequest) returns (RegisterResourceResponse);
-	rpc UnregisterResource(UnregisterResourceRequest) returns (EmptyResponse);
+	rpc UnregisterResource(UnregisterResourceRequest) returns (Empty);
 
 	// Image Classification API
 	rpc ImageClassification(ImageClassificationRequest) returns (ImageClassificationResponse);
 
 	// TensorFlow inference API
 	rpc TensorflowModelLoad(TensorflowModelLoadRequest) returns (TensorflowModelLoadResponse);
-	rpc TensorflowModelUnload(TensorflowModelUnloadRequest) returns (TensorflowModelUnloadResponse);
+	rpc TensorflowModelUnload(TensorflowModelUnloadRequest) returns (Empty);
 	rpc TensorflowModelRun(TensorflowModelRunRequest) returns (TensorflowModelRunResponse);
 
 	// TensorFlow Lite inference API
-	rpc TensorflowLiteModelLoad(TensorflowLiteModelLoadRequest) returns (TensorflowLiteModelLoadResponse);
-	rpc TensorflowLiteModelUnload(TensorflowLiteModelUnloadRequest) returns (TensorflowLiteModelUnloadResponse);
+	rpc TensorflowLiteModelLoad(TensorflowLiteModelLoadRequest) returns (Empty);
+	rpc TensorflowLiteModelUnload(TensorflowLiteModelUnloadRequest) returns (Empty);
 	rpc TensorflowLiteModelRun(TensorflowLiteModelRunRequest) returns (TensorflowLiteModelRunResponse);
 
 	// PyTorch inference API
-	//rpc TorchModelLoad(TorchModelLoadRequest) returns (TorchModelLoadResponse);
-	//rpc TorchModelUnload(TorchModelUnloadRequest) returns (TorchModelUnloadResponse);
 	rpc TorchJitloadForward(TorchJitloadForwardRequest) returns (TorchJitloadForwardResponse);
 
 	// Generic Operation API
@@ -47,5 +46,3 @@ service AgentService {
 	// Profiling Operation API
 	rpc GetTimers(ProfilingRequest) returns (ProfilingResponse);
 }
-
-message EmptyResponse {}

--- a/vaccel-rpc-proto/protos/async/agent.proto
+++ b/vaccel-rpc-proto/protos/async/agent.proto
@@ -28,7 +28,7 @@ service AgentService {
 
 	// TensorFlow inference API
 	rpc TensorflowModelLoad(TensorflowModelLoadRequest) returns (TensorflowModelLoadResponse);
-	rpc TensorflowModelUnload(TensorflowModelUnloadRequest) returns (Empty);
+	rpc TensorflowModelUnload(TensorflowModelUnloadRequest) returns (TensorflowModelUnloadResponse);
 	rpc TensorflowModelRun(TensorflowModelRunRequest) returns (TensorflowModelRunResponse);
 
 	// TensorFlow Lite inference API

--- a/vaccel-rpc-proto/protos/empty.proto
+++ b/vaccel-rpc-proto/protos/empty.proto
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+package vaccel;
+
+message Empty {}

--- a/vaccel-rpc-proto/protos/error.proto
+++ b/vaccel-rpc-proto/protos/error.proto
@@ -4,21 +4,23 @@ syntax = "proto3";
 
 package vaccel;
 
+message VaccelStatus {
+	uint32 code = 3;
+	string message = 4;
+}
+
 enum VaccelErrorType {
-	RUNTIME = 0;
-	VACCEL_WITH_STATUS = 1;
+	FFI = 0;
+	FFI_WITH_STATUS = 1;
 	INVALID_ARGUMENT = 2;
 	UNINITIALIZED = 3;
-	TENSORFLOW = 4;
-	TENSORFLOW_LITE = 5;
-	TORCH = 6;
-	OTHERS = 7;
+	OUT_OF_BOUNDS = 4;
+	EMPTY_VALUE = 5;
+	CONVERSION_FAILED = 6;
 }
 
 message VaccelError {
 	VaccelErrorType type = 1;
-	uint32 ffi_error = 2;
-
-	optional uint32 code = 3;
-	optional string message = 4;
+	optional uint32 ffi_error = 2;
+	optional VaccelStatus status = 3;
 }

--- a/vaccel-rpc-proto/protos/error.proto
+++ b/vaccel-rpc-proto/protos/error.proto
@@ -4,9 +4,21 @@ syntax = "proto3";
 
 package vaccel;
 
+enum VaccelErrorType {
+	RUNTIME = 0;
+	VACCEL_WITH_STATUS = 1;
+	INVALID_ARGUMENT = 2;
+	UNINITIALIZED = 3;
+	TENSORFLOW = 4;
+	TENSORFLOW_LITE = 5;
+	TORCH = 6;
+	OTHERS = 7;
+}
+
 message VaccelError {
-	oneof error {
-		int64 vaccel_error = 1;
-		int64 agent_error = 2;
-	}
-};
+	VaccelErrorType type = 1;
+	uint32 ffi_error = 2;
+
+	optional uint32 code = 3;
+	optional string message = 4;
+}

--- a/vaccel-rpc-proto/protos/genop.proto
+++ b/vaccel-rpc-proto/protos/genop.proto
@@ -12,22 +12,15 @@ message Arg {
 	bytes buf = 3;
 	uint32 parts = 4;
 	uint32 part_no = 5;
-};
+}
 
 message GenopRequest {
 	int64 session_id = 1;
 
 	repeated Arg read_args = 2;
 	repeated Arg write_args = 3;
-};
-
-message GenopResult {
-	repeated Arg write_args = 1;
-};
+}
 
 message GenopResponse {
-	oneof result {
-		VaccelError error = 1;
-		GenopResult result = 2;
-	}
-};
+	repeated Arg write_args = 1;
+}

--- a/vaccel-rpc-proto/protos/profiling.proto
+++ b/vaccel-rpc-proto/protos/profiling.proto
@@ -6,10 +6,6 @@ package vaccel;
 
 import "error.proto";
 
-message ProfilingRequest {
-	int64 session_id = 1;
-};
-
 message ProfRegion {
 	message Sample {
 		uint64 start = 1;
@@ -17,12 +13,12 @@ message ProfRegion {
 	}
 	string name = 1;
 	repeated Sample samples = 2;
-};
+}
 
-message ProfRegions {
-	repeated ProfRegion timer = 1;
-};
+message ProfilingRequest {
+	int64 session_id = 1;
+}
 
 message ProfilingResponse {
-	ProfRegions result = 1;
-};
+	repeated ProfRegion timers = 1;
+}

--- a/vaccel-rpc-proto/protos/resource.proto
+++ b/vaccel-rpc-proto/protos/resource.proto
@@ -23,10 +23,7 @@ message RegisterResourceRequest {
 }
 
 message RegisterResourceResponse {
-	oneof result {
-		VaccelError error = 1;
-		int64 resource_id = 2;
-	}
+	int64 resource_id = 1;
 }
 
 message UnregisterResourceRequest {

--- a/vaccel-rpc-proto/protos/sync/agent.proto
+++ b/vaccel-rpc-proto/protos/sync/agent.proto
@@ -28,7 +28,7 @@ service AgentService {
 
 	// TensorFlow inference API
 	rpc TensorflowModelLoad(TensorflowModelLoadRequest) returns (TensorflowModelLoadResponse);
-	rpc TensorflowModelUnload(TensorflowModelUnloadRequest) returns (Empty);
+	rpc TensorflowModelUnload(TensorflowModelUnloadRequest) returns (TensorflowModelUnloadResponse);
 	rpc TensorflowModelRun(TensorflowModelRunRequest) returns (TensorflowModelRunResponse);
 
 	// TensorFlow Lite inference API

--- a/vaccel-rpc-proto/protos/sync/agent.proto
+++ b/vaccel-rpc-proto/protos/sync/agent.proto
@@ -2,42 +2,41 @@
 
 syntax = "proto3";
 
-import "session.proto";
-import "resource.proto";
+import "empty.proto";
+import "genop.proto";
 import "image.proto";
+import "profiling.proto";
+import "resource.proto";
+import "session.proto";
 import "tensorflow.proto";
 import "torch.proto";
-import "genop.proto";
-import "profiling.proto";
 
 package vaccel;
 
 service AgentService {
 	// Session handling
 	rpc CreateSession(CreateSessionRequest) returns (CreateSessionResponse);
-	rpc UpdateSession(UpdateSessionRequest) returns (EmptyResponse);
-	rpc DestroySession(DestroySessionRequest) returns (EmptyResponse);
+	rpc UpdateSession(UpdateSessionRequest) returns (Empty);
+	rpc DestroySession(DestroySessionRequest) returns (Empty);
 
 	// vAccel resource handling
 	rpc RegisterResource(RegisterResourceRequest) returns (RegisterResourceResponse);
-	rpc UnregisterResource(UnregisterResourceRequest) returns (EmptyResponse);
+	rpc UnregisterResource(UnregisterResourceRequest) returns (Empty);
 
 	// Image Classification API
 	rpc ImageClassification(ImageClassificationRequest) returns (ImageClassificationResponse);
 
 	// TensorFlow inference API
 	rpc TensorflowModelLoad(TensorflowModelLoadRequest) returns (TensorflowModelLoadResponse);
-	rpc TensorflowModelUnload(TensorflowModelUnloadRequest) returns (TensorflowModelUnloadResponse);
+	rpc TensorflowModelUnload(TensorflowModelUnloadRequest) returns (Empty);
 	rpc TensorflowModelRun(TensorflowModelRunRequest) returns (TensorflowModelRunResponse);
 
 	// TensorFlow Lite inference API
-	rpc TensorflowLiteModelLoad(TensorflowLiteModelLoadRequest) returns (TensorflowLiteModelLoadResponse);
-	rpc TensorflowLiteModelUnload(TensorflowLiteModelUnloadRequest) returns (TensorflowLiteModelUnloadResponse);
+	rpc TensorflowLiteModelLoad(TensorflowLiteModelLoadRequest) returns (Empty);
+	rpc TensorflowLiteModelUnload(TensorflowLiteModelUnloadRequest) returns (Empty);
 	rpc TensorflowLiteModelRun(TensorflowLiteModelRunRequest) returns (TensorflowLiteModelRunResponse);
 
 	// PyTorch inference API
-	//rpc TorchModelLoad(TorchModelLoadRequest) returns (TorchModelLoadResponse);
-	//rpc TorchModelUnload(TorchModelUnloadRequest) returns (TorchModelUnloadResponse);
 	rpc TorchJitloadForward(TorchJitloadForwardRequest) returns (TorchJitloadForwardResponse);
 
 	// Generic Operation API
@@ -46,5 +45,3 @@ service AgentService {
 	// Profiling Operation API
 	rpc GetTimers(ProfilingRequest) returns (ProfilingResponse);
 }
-
-message EmptyResponse {}

--- a/vaccel-rpc-proto/protos/tensorflow.proto
+++ b/vaccel-rpc-proto/protos/tensorflow.proto
@@ -13,11 +13,17 @@ message TensorflowModelLoadRequest {
 
 message TensorflowModelLoadResponse {
 	bytes graph_def = 1;
+
+	optional VaccelStatus status = 2;
 }
 
 message TensorflowModelUnloadRequest {
 	int64 session_id = 1;
 	int64 model_id = 2;
+}
+
+message TensorflowModelUnloadResponse {
+	optional VaccelStatus status = 1;
 }
 
 enum TFDataType {
@@ -86,6 +92,8 @@ message TensorflowModelRunRequest {
 message TensorflowModelRunResponse {
 	// An inference result is a number of output tensors
 	repeated TFTensor out_tensors = 1;
+
+	optional VaccelStatus status = 2;
 }
 
 /* TFLite */
@@ -149,4 +157,6 @@ message TensorflowLiteModelRunRequest {
 message TensorflowLiteModelRunResponse {
 	// An inference result is a number of output tensors
 	repeated TFLiteTensor out_tensors = 1;
+
+	optional VaccelStatus status = 2;
 }

--- a/vaccel-rpc-proto/protos/tensorflow.proto
+++ b/vaccel-rpc-proto/protos/tensorflow.proto
@@ -9,24 +9,16 @@ import "error.proto";
 message TensorflowModelLoadRequest {
 	int64 session_id = 1;
 	int64 model_id = 2;
-};
+}
 
 message TensorflowModelLoadResponse {
-	oneof result {
-		bytes graph_def = 1;
-		VaccelError error = 2;
-	}
-};
+	bytes graph_def = 1;
+}
 
 message TensorflowModelUnloadRequest {
 	int64 session_id = 1;
 	int64 model_id = 2;
-};
-
-message TensorflowModelUnloadResponse {
-	bool success = 1;
-	VaccelError error = 2;
-};
+}
 
 enum TFDataType {
 	// Add unused value here so that we are compatible
@@ -55,7 +47,7 @@ enum TFDataType {
 	VARIANT = 21;
 	UINT32 = 22;
 	UINT64 = 23;
-};
+}
 
 message TFTensor {
 	// Data of the tensor
@@ -66,7 +58,7 @@ message TFTensor {
 
 	// Data type
 	TFDataType type = 3;
-};
+}
 
 message TFNode {
 	// Name of the node
@@ -74,7 +66,7 @@ message TFNode {
 
 	// Id of the node
 	int32 id = 2;
-};
+}
 
 message TensorflowModelRunRequest {
 	int64 session_id = 1;
@@ -89,43 +81,24 @@ message TensorflowModelRunRequest {
 
 	// Output nodes
 	repeated TFNode out_nodes = 6;
-};
-
-message InferenceResult {
-	// An inference result is a number of output tensors
-	repeated TFTensor out_tensors = 1;
-};
+}
 
 message TensorflowModelRunResponse {
-	oneof result {
-		VaccelError error = 1;
-		InferenceResult result = 2;
-	}
-};
+	// An inference result is a number of output tensors
+	repeated TFTensor out_tensors = 1;
+}
 
 /* TFLite */
 
 message TensorflowLiteModelLoadRequest {
 	int64 session_id = 1;
 	int64 model_id = 2;
-};
-
-message TensorflowLiteModelLoadResponse {
-	oneof result {
-		VaccelError error = 1;
-	}
-};
+}
 
 message TensorflowLiteModelUnloadRequest {
 	int64 session_id = 1;
 	int64 model_id = 2;
-};
-
-message TensorflowLiteModelUnloadResponse {
-	oneof result {
-		VaccelError error = 1;
-	}
-};
+}
 
 enum TFLiteType {
 	// Add unused value here so that we are compatible
@@ -150,7 +123,7 @@ enum TFLiteType {
 	UINT32 = 17;
 	UINT16 = 18;
 	INT4 = 19;
-};
+}
 
 message TFLiteTensor {
 	// Data of the tensor
@@ -161,7 +134,7 @@ message TFLiteTensor {
 
 	// Data type
 	TFLiteType type = 3;
-};
+}
 
 message TensorflowLiteModelRunRequest {
 	int64 session_id = 1;
@@ -171,16 +144,9 @@ message TensorflowLiteModelRunRequest {
 	repeated TFLiteTensor in_tensors = 3;
 	// Number of output tensors
 	int32 nr_outputs = 4;
-};
-
-message InferenceLiteResult {
-	// An inference result is a number of output tensors
-	repeated TFLiteTensor out_tensors = 1;
-};
+}
 
 message TensorflowLiteModelRunResponse {
-	oneof result {
-		VaccelError error = 1;
-		InferenceLiteResult result = 2;
-	}
-};
+	// An inference result is a number of output tensors
+	repeated TFLiteTensor out_tensors = 1;
+}

--- a/vaccel-rpc-proto/protos/torch.proto
+++ b/vaccel-rpc-proto/protos/torch.proto
@@ -17,7 +17,7 @@ enum TorchDataType {
 	Int64 = 5;
 	Half = 6;
 	FLOAT = 7;
-};
+}
 
 message TorchTensor {
 	// Data of the tensor
@@ -28,7 +28,7 @@ message TorchTensor {
 
 	// Data type
 	TorchDataType type = 3;
-};
+}
 
 // Jitload_forward
 message TorchJitloadForwardRequest {
@@ -43,16 +43,9 @@ message TorchJitloadForwardRequest {
 
 	// Number of output tensors
 	int32 nr_outputs = 5;
-};
-
-message TorchJitloadForwardResult {
-	// An inference result is a number of output tensors
-	repeated TorchTensor out_tensors = 1;
-};
+}
 
 message TorchJitloadForwardResponse {
-	oneof result {
-		VaccelError error = 1;
-		TorchJitloadForwardResult result = 2;
-	}
-};
+	// An inference result is a number of output tensors
+	repeated TorchTensor out_tensors = 1;
+}


### PR DESCRIPTION
Cleanup error variants and properly handle RPC errors:
- Properly return errors from `vaccel-rpc-agent`'s service handlers using RPC errors
- Abstract agent's RPC results/errors to separate business from protocol implementation
- Transparently pass host vaccel errors to client/plugin
- Cleanup RPC `.proto` messages
- Cleanup and improve error variants in all components