### PR TITLE
fix: Correctly pass tensor data ownership to C

### DIFF
--- a/vaccel-bindings/src/ops/tensorflow/lite/tensor.rs
+++ b/vaccel-bindings/src/ops/tensorflow/lite/tensor.rs
@@ -213,13 +213,17 @@ impl<T: TensorType> TensorAny for Tensor<T> {
 
 impl TensorAny for TFLiteTensor {
     fn inner(&self) -> Result<*const ffi::vaccel_tflite_tensor> {
+        let size = self.data.len();
+        let data = &self.data;
+
         let mut inner: *mut ffi::vaccel_tflite_tensor = std::ptr::null_mut();
         match unsafe {
-            ffi::vaccel_tflite_tensor_new(
+            ffi::vaccel_tflite_tensor_allocate(
                 &mut inner,
                 self.dims.len() as i32,
                 self.dims.as_ptr() as *mut _,
                 self.type_.value() as u32,
+                size,
             ) as u32
         } {
             ffi::VACCEL_OK => (),
@@ -227,30 +231,26 @@ impl TensorAny for TFLiteTensor {
         }
         assert!(!inner.is_null());
 
-        let size = self.data.len();
-        let data = self.data.to_owned();
-
-        match unsafe {
-            ffi::vaccel_tflite_tensor_set_data(inner, data.as_ptr() as *mut libc::c_void, size)
-                as u32
-        } {
-            ffi::VACCEL_OK => (),
-            err => return Err(Error::Ffi(err)),
+        unsafe {
+            std::ptr::copy_nonoverlapping(data.as_ptr(), (*inner).data as *mut u8, size);
+            (*inner).size = size;
         }
-
-        std::mem::forget(data);
 
         Ok(inner)
     }
 
     fn inner_mut(&mut self) -> Result<*mut ffi::vaccel_tflite_tensor> {
+        let size = self.data.len();
+        let data = &self.data;
+
         let mut inner: *mut ffi::vaccel_tflite_tensor = std::ptr::null_mut();
         match unsafe {
-            ffi::vaccel_tflite_tensor_new(
+            ffi::vaccel_tflite_tensor_allocate(
                 &mut inner,
                 self.dims.len() as i32,
                 self.dims.as_ptr() as *mut _,
                 self.type_.value() as u32,
+                size,
             ) as u32
         } {
             ffi::VACCEL_OK => (),
@@ -258,18 +258,10 @@ impl TensorAny for TFLiteTensor {
         }
         assert!(!inner.is_null());
 
-        let size = self.data.len();
-        let data = self.data.to_owned();
-
-        match unsafe {
-            ffi::vaccel_tflite_tensor_set_data(inner, data.as_ptr() as *mut libc::c_void, size)
-                as u32
-        } {
-            ffi::VACCEL_OK => (),
-            err => return Err(Error::Ffi(err)),
+        unsafe {
+            std::ptr::copy_nonoverlapping(data.as_ptr(), (*inner).data as *mut u8, size);
+            (*inner).size = size;
         }
-
-        std::mem::forget(data);
 
         Ok(inner)
     }

--- a/vaccel-bindings/src/ops/tensorflow/status.rs
+++ b/vaccel-bindings/src/ops/tensorflow/status.rs
@@ -5,7 +5,7 @@ use derive_more::Display;
 use std::ffi::{CStr, CString};
 use vaccel_rpc_proto::error::VaccelStatus;
 
-#[derive(Debug, Default, Display)]
+#[derive(Debug, Default, Display, Clone)]
 #[display("{} ({})", self.message(), self.error_code())]
 pub struct Status {
     inner: ffi::vaccel_tf_status,

--- a/vaccel-bindings/src/ops/torch/tensor.rs
+++ b/vaccel-bindings/src/ops/torch/tensor.rs
@@ -224,13 +224,17 @@ impl<T: TensorType> TensorAny for Tensor<T> {
 
 impl TensorAny for TorchTensor {
     fn inner(&self) -> Result<*const ffi::vaccel_torch_tensor> {
+        let size = self.data.len();
+        let data = &self.data;
+
         let mut inner: *mut ffi::vaccel_torch_tensor = std::ptr::null_mut();
         match unsafe {
-            ffi::vaccel_torch_tensor_new(
+            ffi::vaccel_torch_tensor_allocate(
                 &mut inner,
                 self.dims.len() as i64,
                 self.dims.as_ptr() as *mut _,
                 self.type_.value() as u32,
+                size,
             ) as u32
         } {
             ffi::VACCEL_OK => (),
@@ -238,30 +242,26 @@ impl TensorAny for TorchTensor {
         }
         assert!(!inner.is_null());
 
-        let size = self.data.len();
-        let data = self.data.to_owned();
-
-        match unsafe {
-            ffi::vaccel_torch_tensor_set_data(inner, data.as_ptr() as *mut libc::c_void, size)
-                as u32
-        } {
-            ffi::VACCEL_OK => (),
-            err => return Err(Error::Ffi(err)),
+        unsafe {
+            std::ptr::copy_nonoverlapping(data.as_ptr(), (*inner).data as *mut u8, size);
+            (*inner).size = size;
         }
-
-        std::mem::forget(data);
 
         Ok(inner)
     }
 
     fn inner_mut(&mut self) -> Result<*mut ffi::vaccel_torch_tensor> {
+        let size = self.data.len();
+        let data = &self.data;
+
         let mut inner: *mut ffi::vaccel_torch_tensor = std::ptr::null_mut();
         match unsafe {
-            ffi::vaccel_torch_tensor_new(
+            ffi::vaccel_torch_tensor_allocate(
                 &mut inner,
                 self.dims.len() as i64,
-                self.dims.as_mut_ptr() as *mut _,
+                self.dims.as_ptr() as *mut _,
                 self.type_.value() as u32,
+                size,
             ) as u32
         } {
             ffi::VACCEL_OK => (),
@@ -269,18 +269,10 @@ impl TensorAny for TorchTensor {
         }
         assert!(!inner.is_null());
 
-        let size = self.data.len();
-        let data = self.data.to_owned();
-
-        match unsafe {
-            ffi::vaccel_torch_tensor_set_data(inner, data.as_ptr() as *mut libc::c_void, size)
-                as u32
-        } {
-            ffi::VACCEL_OK => (),
-            err => return Err(Error::Ffi(err)),
+        unsafe {
+            std::ptr::copy_nonoverlapping(data.as_ptr(), (*inner).data as *mut u8, size);
+            (*inner).size = size;
         }
-
-        std::mem::forget(data);
 
         Ok(inner)
     }

--- a/vaccel-rpc-agent/src/ops/tf.rs
+++ b/vaccel-rpc-agent/src/ops/tf.rs
@@ -135,7 +135,7 @@ impl AgentService {
 
         let mut resp = TensorflowModelRunResponse::new();
         resp.out_tensors = out_tensors;
-        resp.status = Some(result.status.into()).into();
+        resp.status = Some(result.status.clone().into()).into();
 
         Ok(resp)
     }

--- a/vaccel-rpc-client/src/ops/tflite.rs
+++ b/vaccel-rpc-client/src/ops/tflite.rs
@@ -77,28 +77,21 @@ impl VaccelRpcClient {
                 let data = e.data;
 
                 let mut tensor = std::ptr::null_mut();
-                match ffi::vaccel_tflite_tensor_new(
+                match ffi::vaccel_tflite_tensor_allocate(
                     &mut tensor,
                     dims.len() as i32,
                     dims.as_ptr() as *mut _,
                     data_type as u32,
-                ) as u32
-                {
-                    ffi::VACCEL_OK => (),
-                    err => return Err(vaccel::Error::Ffi(err)),
-                }
-
-                match ffi::vaccel_tflite_tensor_set_data(
-                    tensor,
-                    data.as_ptr() as *mut std::ffi::c_void,
                     data.len(),
                 ) as u32
                 {
                     ffi::VACCEL_OK => (),
                     err => return Err(vaccel::Error::Ffi(err)),
                 }
+                assert!(!tensor.is_null());
 
-                std::mem::forget(data);
+                std::ptr::copy_nonoverlapping(data.as_ptr(), (*tensor).data as *mut u8, data.len());
+                (*tensor).size = data.len();
 
                 Ok(tensor)
             })

--- a/vaccel-rpc-client/src/ops/torch.rs
+++ b/vaccel-rpc-client/src/ops/torch.rs
@@ -44,28 +44,21 @@ impl VaccelRpcClient {
                 let data = e.data;
 
                 let mut tensor = std::ptr::null_mut();
-                match ffi::vaccel_torch_tensor_new(
+                match ffi::vaccel_torch_tensor_allocate(
                     &mut tensor,
                     dims.len() as i64,
                     dims.as_ptr() as *mut i64,
                     data_type as u32,
-                ) as u32
-                {
-                    ffi::VACCEL_OK => (),
-                    err => return Err(vaccel::Error::Ffi(err).into()),
-                }
-
-                match ffi::vaccel_torch_tensor_set_data(
-                    tensor,
-                    data.as_ptr() as *mut std::ffi::c_void,
                     data.len(),
                 ) as u32
                 {
                     ffi::VACCEL_OK => (),
                     err => return Err(vaccel::Error::Ffi(err).into()),
                 }
+                assert!(!tensor.is_null());
 
-                std::mem::forget(data);
+                std::ptr::copy_nonoverlapping(data.as_ptr(), (*tensor).data as *mut u8, data.len());
+                (*tensor).size = data.len();
 
                 Ok(tensor)
             })


### PR DESCRIPTION
Copy the tensor data to the respective C-allocated tensor buffer so the C API can properly handle memory freeing and Rust does not need to track the data's lifetime.