### PR TITLE
fix: Correctly handle `NULL` value in Torch/TF `run_options`

### DIFF
--- a/vaccel-bindings/examples/tf_inference.rs
+++ b/vaccel-bindings/examples/tf_inference.rs
@@ -49,19 +49,17 @@ fn main() -> utilities::Result<()> {
     }
 
     // Prepare data for inference
-    let run_options = tf::Buffer::new(&[])?;
     let in_tensor = tf::Tensor::<f32>::new(&[1, 30])?.with_data(&[1.0; 30])?;
     let in_node = tf::Node::new("serving_default_input_1", 0)?;
     let out_node = tf::Node::new("StatefulPartitionedCall", 0)?;
 
     let mut sess_args = tf::InferenceArgs::new();
-    sess_args.set_run_options(&run_options);
     sess_args.add_input(&in_node, &in_tensor)?;
     sess_args.request_output(&out_node);
 
     // Run inference
-    let result = tf_model.as_mut().run(&mut sess, &mut sess_args)?;
-    match result.get_output::<f32>(0) {
+    let mut result = tf_model.as_mut().run(&mut sess, &mut sess_args)?;
+    match result.take_output::<f32>(0) {
         Ok(out) => {
             println!("Success!");
             println!(

--- a/vaccel-bindings/examples/tflite_inference.rs
+++ b/vaccel-bindings/examples/tflite_inference.rs
@@ -56,8 +56,8 @@ fn main() -> utilities::Result<()> {
     sess_args.set_nr_outputs(1);
 
     // Run inference
-    let result = tflite_model.as_mut().run(&mut sess, &mut sess_args)?;
-    match result.get_output::<f32>(0) {
+    let mut result = tflite_model.as_mut().run(&mut sess, &mut sess_args)?;
+    match result.take_output::<f32>(0) {
         Ok(out) => {
             println!("Success!");
             println!(

--- a/vaccel-bindings/src/ops/tensorflow/lite/tensor.rs
+++ b/vaccel-bindings/src/ops/tensorflow/lite/tensor.rs
@@ -2,6 +2,7 @@
 
 use super::DataType;
 use crate::{ffi, Error, Result};
+use log::warn;
 use protobuf::Enum;
 use std::ops::{Deref, DerefMut};
 use vaccel_rpc_proto::tensorflow::{TFLiteTensor, TFLiteType};
@@ -184,7 +185,10 @@ impl<T: TensorType> Drop for Tensor<T> {
             return;
         }
 
-        unsafe { ffi::vaccel_tflite_tensor_delete(self.inner) };
+        let ret = unsafe { ffi::vaccel_tflite_tensor_delete(self.inner) } as u32;
+        if ret != ffi::VACCEL_OK {
+            warn!("Could not delete TFLite tensor: {}", ret);
+        }
         self.inner = std::ptr::null_mut();
     }
 }

--- a/vaccel-bindings/src/ops/tensorflow/tensor.rs
+++ b/vaccel-bindings/src/ops/tensorflow/tensor.rs
@@ -2,6 +2,7 @@
 
 use super::DataType;
 use crate::{ffi, Error, Result};
+use log::warn;
 use protobuf::Enum;
 use std::ops::{Deref, DerefMut};
 use vaccel_rpc_proto::tensorflow::{TFDataType, TFTensor};
@@ -184,7 +185,10 @@ impl<T: TensorType> Drop for Tensor<T> {
             return;
         }
 
-        unsafe { ffi::vaccel_tf_tensor_delete(self.inner) };
+        let ret = unsafe { ffi::vaccel_tf_tensor_delete(self.inner) } as u32;
+        if ret != ffi::VACCEL_OK {
+            warn!("Could not delete TF tensor: {}", ret);
+        }
         self.inner = std::ptr::null_mut();
     }
 }

--- a/vaccel-bindings/src/ops/torch/model.rs
+++ b/vaccel-bindings/src/ops/torch/model.rs
@@ -32,8 +32,10 @@ impl InferenceArgs {
         }
     }
 
-    pub fn set_run_options(&mut self, run_opts: &Buffer) {
-        self.run_options = run_opts.inner();
+    pub fn set_run_options(&mut self, run_opts: Option<&Buffer>) {
+        if let Some(opts) = run_opts {
+            self.run_options = opts.inner();
+        }
     }
 
     // TODO: &TorchTensor -> TensorAny
@@ -50,6 +52,9 @@ impl InferenceArgs {
 impl Drop for InferenceArgs {
     fn drop(&mut self) {
         while let Some(tensor_ptr) = self.in_tensors.pop() {
+            if tensor_ptr.is_null() {
+                continue;
+            }
             let ret = unsafe { ffi::vaccel_torch_tensor_delete(tensor_ptr as *mut _) } as u32;
             if ret != ffi::VACCEL_OK {
                 warn!("Could not delete Torch tensor: {}", ret);
@@ -76,7 +81,7 @@ impl InferenceResult {
         }
     }
 
-    pub fn get_output<T: TensorType>(&self, id: usize) -> Result<Tensor<T>> {
+    pub fn take_output<T: TensorType>(&mut self, id: usize) -> Result<Tensor<T>> {
         if id >= self.out_tensors.len() {
             return Err(Error::OutOfBounds);
         }
@@ -90,10 +95,13 @@ impl InferenceResult {
             return Err(Error::InvalidArgument("Invalid `data_type`".to_string()));
         }
 
-        Ok(unsafe { Tensor::from_ffi(t)? })
+        let tensor: Tensor<T> = unsafe { Tensor::from_ffi(t)? };
+        self.out_tensors[id] = std::ptr::null_mut();
+
+        Ok(tensor)
     }
 
-    pub fn get_grpc_output(&self, id: usize) -> Result<TorchTensor> {
+    pub fn to_grpc_output(&self, id: usize) -> Result<TorchTensor> {
         if id >= self.out_tensors.len() {
             return Err(Error::OutOfBounds);
         }
@@ -120,6 +128,9 @@ impl InferenceResult {
 impl Drop for InferenceResult {
     fn drop(&mut self) {
         while let Some(tensor_ptr) = self.out_tensors.pop() {
+            if tensor_ptr.is_null() {
+                continue;
+            }
             let ret = unsafe { ffi::vaccel_torch_tensor_delete(tensor_ptr as *mut _) } as u32;
             if ret != ffi::VACCEL_OK {
                 warn!("Could not delete Torch tensor: {}", ret);

--- a/vaccel-bindings/src/ops/torch/tensor.rs
+++ b/vaccel-bindings/src/ops/torch/tensor.rs
@@ -2,6 +2,7 @@
 
 use super::DataType;
 use crate::{ffi, Error, Result};
+use log::warn;
 use protobuf::Enum;
 use std::ops::{Deref, DerefMut};
 use vaccel_rpc_proto::torch::{TorchDataType, TorchTensor};
@@ -195,7 +196,10 @@ impl<T: TensorType> Drop for Tensor<T> {
             return;
         }
 
-        unsafe { ffi::vaccel_torch_tensor_delete(self.inner) };
+        let ret = unsafe { ffi::vaccel_torch_tensor_delete(self.inner) } as u32;
+        if ret != ffi::VACCEL_OK {
+            warn!("Could not delete Torch tensor: {}", ret);
+        }
         self.inner = std::ptr::null_mut();
     }
 }

--- a/vaccel-rpc-agent/src/ops/tf.rs
+++ b/vaccel-rpc-agent/src/ops/tf.rs
@@ -99,8 +99,11 @@ impl AgentService {
 
         let mut sess_args = tf::InferenceArgs::new();
 
-        let run_options = tf::Buffer::new(req.run_options.as_slice())?;
-        sess_args.set_run_options(&run_options);
+        let run_options = req
+            .run_options
+            .map(|opts| tf::Buffer::new(opts.as_slice()))
+            .transpose()?;
+        sess_args.set_run_options(run_options.as_ref());
 
         let in_nodes: Vec<tf::Node> = req
             .in_nodes
@@ -130,7 +133,7 @@ impl AgentService {
 
         let mut out_tensors: Vec<TFTensor> = Vec::with_capacity(num_outputs);
         for i in 0..num_outputs {
-            out_tensors.push(result.get_grpc_output(i)?);
+            out_tensors.push(result.to_grpc_output(i)?);
         }
 
         let mut resp = TensorflowModelRunResponse::new();

--- a/vaccel-rpc-agent/src/ops/tflite.rs
+++ b/vaccel-rpc-agent/src/ops/tflite.rs
@@ -114,7 +114,7 @@ impl AgentService {
 
         let mut out_tensors: Vec<TFLiteTensor> = Vec::with_capacity(num_outputs);
         for i in 0..num_outputs {
-            out_tensors.push(result.get_grpc_output(i)?);
+            out_tensors.push(result.to_grpc_output(i)?);
         }
 
         let mut resp = TensorflowLiteModelRunResponse::new();

--- a/vaccel-rpc-client/src/ops/tf.rs
+++ b/vaccel-rpc-client/src/ops/tf.rs
@@ -55,7 +55,7 @@ impl VaccelRpcClient {
         &self,
         model_id: i64,
         session_id: i64,
-        run_options: Vec<u8>,
+        run_options: Option<Vec<u8>>,
         in_nodes: Vec<TFNode>,
         in_tensors: Vec<TFTensor>,
         out_nodes: Vec<TFNode>,
@@ -200,9 +200,11 @@ pub unsafe extern "C" fn vaccel_rpc_client_tf_session_run(
     status_ptr: *mut ffi::vaccel_tf_status,
 ) -> c_int {
     let run_options = unsafe {
-        c_pointer_to_slice((*run_options_ptr).data as *mut u8, (*run_options_ptr).size)
-            .unwrap_or(&[])
-            .to_owned()
+        run_options_ptr.as_ref().map(|opts| {
+            c_pointer_to_slice(opts.data as *mut u8, opts.size)
+                .unwrap_or(&[])
+                .to_owned()
+        })
     };
 
     let in_nodes: Vec<TFNode> =

--- a/vaccel-rpc-client/src/ops/torch.rs
+++ b/vaccel-rpc-client/src/ops/torch.rs
@@ -19,7 +19,7 @@ impl VaccelRpcClient {
         &self,
         session_id: i64,
         model_id: i64,
-        run_options: Vec<u8>,
+        run_options: Option<Vec<u8>>,
         in_tensors: Vec<TorchTensor>,
         nr_outputs: i32,
     ) -> Result<Vec<*mut ffi::vaccel_torch_tensor>> {
@@ -85,9 +85,11 @@ pub unsafe extern "C" fn vaccel_rpc_client_torch_jitload_forward(
     nr_outputs: c_int,
 ) -> c_int {
     let run_options = unsafe {
-        c_pointer_to_slice((*run_options_ptr).data as *mut u8, (*run_options_ptr).size)
-            .unwrap_or(&[])
-            .to_owned()
+        run_options_ptr.as_ref().map(|opts| {
+            c_pointer_to_slice(opts.data as *mut u8, opts.size)
+                .unwrap_or(&[])
+                .to_owned()
+        })
     };
 
     let in_tensors: Vec<TorchTensor> =

--- a/vaccel-rpc-proto/protos/tensorflow.proto
+++ b/vaccel-rpc-proto/protos/tensorflow.proto
@@ -79,7 +79,7 @@ message TensorflowModelRunRequest {
 	int64 model_id = 2;
 
 	// Run options
-	bytes run_options = 3;
+	optional bytes run_options = 3;
 
 	// Input nodes & tensors
 	repeated TFNode in_nodes = 4;

--- a/vaccel-rpc-proto/protos/torch.proto
+++ b/vaccel-rpc-proto/protos/torch.proto
@@ -36,7 +36,7 @@ message TorchJitloadForwardRequest {
 	int64 model_id = 2;
 
 	// Run options
-	bytes run_options = 3;
+	optional bytes run_options = 3;
 
 	// Input tensors
 	repeated TorchTensor in_tensors = 4;


### PR DESCRIPTION
Check for `NULL` values in Torch/TF `run_options` and properly set the RPC and vAccel call options