### PR TITLE
feat(torch): Introduce model loading operation

### DIFF
--- a/vaccel-rpc-agent/src/asynchronous/agent_service.rs
+++ b/vaccel-rpc-agent/src/asynchronous/agent_service.rs
@@ -20,7 +20,7 @@ use vaccel_rpc_proto::{
     session::{
         CreateSessionRequest, CreateSessionResponse, DestroySessionRequest, UpdateSessionRequest,
     },
-    torch::{TorchJitloadForwardRequest, TorchJitloadForwardResponse},
+    torch::{TorchModelLoadRequest, TorchModelRunRequest, TorchModelRunResponse},
 };
 //use tracing::{info, instrument, Instrument};
 use log::debug;
@@ -126,12 +126,20 @@ impl agent_ttrpc::AgentService for AgentService {
         self.do_tflite_model_run(req).into_ttrpc()
     }
 
-    async fn torch_jitload_forward(
+    async fn torch_model_load(
         &self,
         _ctx: &::ttrpc::asynchronous::TtrpcContext,
-        req: TorchJitloadForwardRequest,
-    ) -> ttrpc::Result<TorchJitloadForwardResponse> {
-        self.do_torch_jitload_forward(req).into_ttrpc()
+        req: TorchModelLoadRequest,
+    ) -> ttrpc::Result<Empty> {
+        self.do_torch_model_load(req).into_ttrpc()
+    }
+
+    async fn torch_model_run(
+        &self,
+        _ctx: &::ttrpc::asynchronous::TtrpcContext,
+        req: TorchModelRunRequest,
+    ) -> ttrpc::Result<TorchModelRunResponse> {
+        self.do_torch_model_run(req).into_ttrpc()
     }
 
     async fn genop(

--- a/vaccel-rpc-agent/src/sync/agent_service.rs
+++ b/vaccel-rpc-agent/src/sync/agent_service.rs
@@ -18,7 +18,7 @@ use vaccel_rpc_proto::{
         CreateSessionRequest, CreateSessionResponse, DestroySessionRequest, UpdateSessionRequest,
     },
     sync::agent_ttrpc,
-    torch::{TorchJitloadForwardRequest, TorchJitloadForwardResponse},
+    torch::{TorchModelLoadRequest, TorchModelRunRequest, TorchModelRunResponse},
 };
 
 impl agent_ttrpc::AgentService for AgentService {
@@ -121,12 +121,20 @@ impl agent_ttrpc::AgentService for AgentService {
         self.do_tflite_model_run(req).into_ttrpc()
     }
 
-    fn torch_jitload_forward(
+    fn torch_model_load(
         &self,
         _ctx: &::ttrpc::sync::TtrpcContext,
-        req: TorchJitloadForwardRequest,
-    ) -> ttrpc::Result<TorchJitloadForwardResponse> {
-        self.do_torch_jitload_forward(req).into_ttrpc()
+        req: TorchModelLoadRequest,
+    ) -> ttrpc::Result<Empty> {
+        self.do_torch_model_load(req).into_ttrpc()
+    }
+
+    fn torch_model_run(
+        &self,
+        _ctx: &::ttrpc::sync::TtrpcContext,
+        req: TorchModelRunRequest,
+    ) -> ttrpc::Result<TorchModelRunResponse> {
+        self.do_torch_model_run(req).into_ttrpc()
     }
 
     fn genop(

--- a/vaccel-rpc-proto/protos/async/agent.proto
+++ b/vaccel-rpc-proto/protos/async/agent.proto
@@ -37,7 +37,8 @@ service AgentService {
 	rpc TensorflowLiteModelRun(TensorflowLiteModelRunRequest) returns (TensorflowLiteModelRunResponse);
 
 	// PyTorch inference API
-	rpc TorchJitloadForward(TorchJitloadForwardRequest) returns (TorchJitloadForwardResponse);
+	rpc TorchModelLoad(TorchModelLoadRequest) returns (Empty);
+	rpc TorchModelRun(TorchModelRunRequest) returns (TorchModelRunResponse);
 
 	// Generic Operation API
 	rpc Genop(GenopRequest) returns (GenopResponse);

--- a/vaccel-rpc-proto/protos/sync/agent.proto
+++ b/vaccel-rpc-proto/protos/sync/agent.proto
@@ -37,7 +37,8 @@ service AgentService {
 	rpc TensorflowLiteModelRun(TensorflowLiteModelRunRequest) returns (TensorflowLiteModelRunResponse);
 
 	// PyTorch inference API
-	rpc TorchJitloadForward(TorchJitloadForwardRequest) returns (TorchJitloadForwardResponse);
+	rpc TorchModelLoad(TorchModelLoadRequest) returns (Empty);
+	rpc TorchModelRun(TorchModelRunRequest) returns (TorchModelRunResponse);
 
 	// Generic Operation API
 	rpc Genop(GenopRequest) returns (GenopResponse);

--- a/vaccel-rpc-proto/protos/torch.proto
+++ b/vaccel-rpc-proto/protos/torch.proto
@@ -30,8 +30,14 @@ message TorchTensor {
 	TorchDataType type = 3;
 }
 
-// Jitload_forward
-message TorchJitloadForwardRequest {
+// Load_model
+message TorchModelLoadRequest {
+	int64 session_id = 1;
+	int64 model_id = 2;
+}
+
+// Model_run
+message TorchModelRunRequest {
 	int64 session_id = 1;
 	int64 model_id = 2;
 
@@ -45,7 +51,7 @@ message TorchJitloadForwardRequest {
 	int32 nr_outputs = 5;
 }
 
-message TorchJitloadForwardResponse {
+message TorchModelRunResponse {
 	// An inference result is a number of output tensors
 	repeated TorchTensor out_tensors = 1;
 }


### PR DESCRIPTION
Split loading from forwarding in Torch. Now model loading takes place in a separate vAccel operation.