### PR TITLE
refactor: Update TF/TFLite ops renamed upstream

### DIFF
--- a/vaccel-bindings/src/ops/tensorflow/lite/model.rs
+++ b/vaccel-bindings/src/ops/tensorflow/lite/model.rs
@@ -156,7 +156,7 @@ impl<'a> ModelRun<'a> for Model<'a> {
     ) -> Result<Self::RunResult> {
         let mut result = InferenceResult::new(args.in_tensors.len());
         match unsafe {
-            ffi::vaccel_tflite_session_run(
+            ffi::vaccel_tflite_model_run(
                 sess.inner_mut(),
                 self.inner_mut().inner_mut(),
                 args.in_tensors.as_ptr() as *const *mut ffi::vaccel_tflite_tensor,
@@ -184,7 +184,7 @@ impl<'a> ModelLoadUnload<'a> for Model<'a> {
 
     fn load(self: Pin<&mut Self>, sess: &mut Session) -> Result<Self::LoadUnloadResult> {
         match unsafe {
-            ffi::vaccel_tflite_session_load(sess.inner_mut(), self.inner_mut().inner_mut()) as u32
+            ffi::vaccel_tflite_model_load(sess.inner_mut(), self.inner_mut().inner_mut()) as u32
         } {
             ffi::VACCEL_OK => Ok(()),
             err => Err(Error::Ffi(err)),
@@ -193,7 +193,7 @@ impl<'a> ModelLoadUnload<'a> for Model<'a> {
 
     fn unload(self: Pin<&mut Self>, sess: &mut Session) -> Result<Self::LoadUnloadResult> {
         match unsafe {
-            ffi::vaccel_tflite_session_delete(sess.inner_mut(), self.inner_mut().inner_mut()) as u32
+            ffi::vaccel_tflite_model_unload(sess.inner_mut(), self.inner_mut().inner_mut()) as u32
         } {
             ffi::VACCEL_OK => Ok(()),
             err => Err(Error::Ffi(err)),

--- a/vaccel-bindings/src/ops/tensorflow/model.rs
+++ b/vaccel-bindings/src/ops/tensorflow/model.rs
@@ -174,7 +174,7 @@ impl<'a> ModelRun<'a> for Model<'a> {
     ) -> Result<Self::RunResult> {
         let mut result = InferenceResult::new(args.out_nodes.len());
         match unsafe {
-            ffi::vaccel_tf_session_run(
+            ffi::vaccel_tf_model_run(
                 sess.inner_mut(),
                 self.inner_mut().inner_mut(),
                 args.run_options,
@@ -217,7 +217,7 @@ impl<'a> ModelLoadUnload<'a> for Model<'a> {
     fn load(self: Pin<&mut Self>, sess: &mut Session) -> Result<Self::LoadUnloadResult> {
         let mut status = Status::default();
         match unsafe {
-            ffi::vaccel_tf_session_load(
+            ffi::vaccel_tf_model_load(
                 sess.inner_mut(),
                 self.inner_mut().inner_mut(),
                 status.inner_mut(),
@@ -238,7 +238,7 @@ impl<'a> ModelLoadUnload<'a> for Model<'a> {
     fn unload(self: Pin<&mut Self>, sess: &mut Session) -> Result<Self::LoadUnloadResult> {
         let mut status = Status::default();
         match unsafe {
-            ffi::vaccel_tf_session_delete(
+            ffi::vaccel_tf_model_unload(
                 sess.inner_mut(),
                 self.inner_mut().inner_mut(),
                 status.inner_mut(),

--- a/vaccel-bindings/src/ops/tensorflow/status.rs
+++ b/vaccel-bindings/src/ops/tensorflow/status.rs
@@ -6,28 +6,28 @@ use std::ffi::{CStr, CString};
 use vaccel_rpc_proto::error::VaccelStatus;
 
 #[derive(Debug, Default, Display, Clone)]
-#[display("{} ({})", self.message(), self.error_code())]
+#[display("{} ({})", self.message(), self.code())]
 pub struct Status {
     inner: ffi::vaccel_tf_status,
 }
 
 impl Status {
-    pub fn new(error_code: u8, message: &str) -> Result<Self> {
+    pub fn new(code: u8, message: &str) -> Result<Self> {
         let mut inner = ffi::vaccel_tf_status::default();
         let c_message = CString::new(message).map_err(|e| {
             Error::ConversionFailed(format!("Could not convert `message` to `CString` [{}]", e))
         })?;
 
         match unsafe {
-            ffi::vaccel_tf_status_init(&mut inner, error_code, c_message.as_c_str().as_ptr()) as u32
+            ffi::vaccel_tf_status_init(&mut inner, code, c_message.as_c_str().as_ptr()) as u32
         } {
             ffi::VACCEL_OK => Ok(Self { inner }),
             err => Err(Error::Ffi(err)),
         }
     }
 
-    pub fn error_code(&self) -> u8 {
-        self.inner.error_code
+    pub fn code(&self) -> u8 {
+        self.inner.code
     }
 
     pub fn message(&self) -> String {
@@ -45,13 +45,13 @@ impl Status {
     /// manually or by the respective vAccel function.
     pub unsafe fn populate_ffi(&self, ptr: *mut ffi::vaccel_tf_status) {
         if let Some(ffi) = unsafe { ptr.as_mut() } {
-            ffi.error_code = self.inner.error_code;
+            ffi.code = self.inner.code;
             ffi.message = self.inner.message;
         }
     }
 
     pub fn is_ok(&self) -> bool {
-        self.error_code() == 0
+        self.code() == 0
     }
 
     pub(crate) fn inner(&self) -> &ffi::vaccel_tf_status {
@@ -79,7 +79,7 @@ impl TryFrom<VaccelStatus> for Status {
 impl From<Status> for VaccelStatus {
     fn from(status: Status) -> Self {
         let mut vaccel_status = Self::new();
-        vaccel_status.code = status.error_code() as u32;
+        vaccel_status.code = status.code() as u32;
         vaccel_status.message = status.message();
         vaccel_status
     }
@@ -103,6 +103,6 @@ impl TryFrom<&ErrorStatus> for Status {
 
 impl From<Status> for ErrorStatus {
     fn from(status: Status) -> Self {
-        Self::new(status.error_code(), &status.message())
+        Self::new(status.code(), &status.message())
     }
 }

--- a/vaccel-rpc-client/src/ops/tf.rs
+++ b/vaccel-rpc-client/src/ops/tf.rs
@@ -125,7 +125,7 @@ impl Error {
 /// `client_ptr` must be a valid pointer to an object obtained by
 /// `create_client()`.
 #[no_mangle]
-pub unsafe extern "C" fn vaccel_rpc_client_tf_session_load(
+pub unsafe extern "C" fn vaccel_rpc_client_tf_model_load(
     client_ptr: *const VaccelRpcClient,
     model_id: ffi::vaccel_id_t,
     sess_id: i64,
@@ -154,7 +154,7 @@ pub unsafe extern "C" fn vaccel_rpc_client_tf_session_load(
 /// `client_ptr` must be a valid pointer to an object obtained by
 /// `create_client()`.
 #[no_mangle]
-pub unsafe extern "C" fn vaccel_rpc_client_tf_session_delete(
+pub unsafe extern "C" fn vaccel_rpc_client_tf_model_unload(
     client_ptr: *const VaccelRpcClient,
     model_id: ffi::vaccel_id_t,
     sess_id: i64,
@@ -186,7 +186,7 @@ pub unsafe extern "C" fn vaccel_rpc_client_tf_session_delete(
 /// `out_tensors_ptr` are expected to be valid pointers to objects allocated
 /// manually or by the respective vAccel functions.
 #[no_mangle]
-pub unsafe extern "C" fn vaccel_rpc_client_tf_session_run(
+pub unsafe extern "C" fn vaccel_rpc_client_tf_model_run(
     client_ptr: *const VaccelRpcClient,
     model_id: ffi::vaccel_id_t,
     sess_id: i64,

--- a/vaccel-rpc-client/src/ops/tflite.rs
+++ b/vaccel-rpc-client/src/ops/tflite.rs
@@ -119,7 +119,7 @@ impl Error {
 /// `client_ptr` must be a valid pointer to an object obtained by
 /// `create_client()`.
 #[no_mangle]
-pub unsafe extern "C" fn vaccel_rpc_client_tflite_session_load(
+pub unsafe extern "C" fn vaccel_rpc_client_tflite_model_load(
     client_ptr: *const VaccelRpcClient,
     model_id: ffi::vaccel_id_t,
     sess_id: i64,
@@ -137,7 +137,7 @@ pub unsafe extern "C" fn vaccel_rpc_client_tflite_session_load(
 /// `client_ptr` must be a valid pointer to an object obtained by
 /// `create_client()`.
 #[no_mangle]
-pub unsafe extern "C" fn vaccel_rpc_client_tflite_session_delete(
+pub unsafe extern "C" fn vaccel_rpc_client_tflite_model_unload(
     client_ptr: *const VaccelRpcClient,
     model_id: ffi::vaccel_id_t,
     sess_id: i64,
@@ -157,7 +157,7 @@ pub unsafe extern "C" fn vaccel_rpc_client_tflite_session_delete(
 /// `in_tensors_ptr` and `out_tensors_ptr` are expected to be valid pointers to
 /// objects allocated manually or by the respective vAccel functions.
 #[no_mangle]
-pub unsafe extern "C" fn vaccel_rpc_client_tflite_session_run(
+pub unsafe extern "C" fn vaccel_rpc_client_tflite_model_run(
     client_ptr: *const VaccelRpcClient,
     model_id: ffi::vaccel_id_t,
     sess_id: i64,


### PR DESCRIPTION
Update TF/TFLite operations renamed upstream in nubificus/vaccel#184