### PR TITLE
feat(vaccel-rpc-client): Add env option to skip sending write arg bufs

### DIFF
--- a/vaccel-rpc-client/src/asynchronous/client.rs
+++ b/vaccel-rpc-client/src/asynchronous/client.rs
@@ -13,6 +13,7 @@ pub struct VaccelRpcClient {
     pub ttrpc_client: AgentServiceClient,
     pub profiler_manager: ProfilerManager,
     pub runtime: Arc<Runtime>,
+    pub send_write: bool,
 }
 
 impl VaccelRpcClient {
@@ -29,6 +30,7 @@ impl VaccelRpcClient {
             ttrpc_client: AgentServiceClient::new(ttrpc_client),
             profiler_manager: ProfilerManager::new(Self::TIMERS_PREFIX),
             runtime: Arc::new(r),
+            send_write: Self::get_env_send_write(),
         })
     }
 

--- a/vaccel-rpc-client/src/client.rs
+++ b/vaccel-rpc-client/src/client.rs
@@ -24,6 +24,13 @@ impl VaccelRpcClient {
         }
     }
 
+    pub fn get_env_send_write() -> bool {
+        match env::var("VACCEL_RPC_SEND_WRITE_ENABLED") {
+            Ok(send) => send == "1",
+            Err(_) => true,
+        }
+    }
+
     pub(crate) fn resolve_uri(uri: &str) -> Result<String> {
         let parts: Vec<&str> = uri.split("://").collect();
         if parts.len() != 2 {

--- a/vaccel-rpc-client/src/ops/genop.rs
+++ b/vaccel-rpc-client/src/ops/genop.rs
@@ -95,7 +95,14 @@ pub unsafe extern "C" fn vaccel_rpc_client_genop(
         let write_args = c_pointer_to_mut_slice(write_args_ptr, nr_write_args).unwrap_or(&mut []);
         let proto_write_args = match write_args
             .iter_mut()
-            .map(|a| Ok(Arg::from_ref(a)?.try_into()?))
+            .map(|a| {
+                let arg = Arg::from_ref(a)?;
+                if client.send_write {
+                    Ok(arg.try_into()?)
+                } else {
+                    Ok(ProtoArg::try_from_vaccel_unallocated(&arg)?)
+                }
+            })
             .collect::<Result<Vec<ProtoArg>>>()
         {
             Ok(arg) => arg,

--- a/vaccel-rpc-client/src/sync/client.rs
+++ b/vaccel-rpc-client/src/sync/client.rs
@@ -10,6 +10,7 @@ use vaccel_rpc_proto::sync::agent_ttrpc::AgentServiceClient;
 pub struct VaccelRpcClient {
     pub ttrpc_client: AgentServiceClient,
     pub profiler_manager: ProfilerManager,
+    pub send_write: bool,
 }
 
 impl VaccelRpcClient {
@@ -22,6 +23,7 @@ impl VaccelRpcClient {
         Ok(VaccelRpcClient {
             ttrpc_client: AgentServiceClient::new(ttrpc_client),
             profiler_manager: ProfilerManager::new(Self::TIMERS_PREFIX),
+            send_write: Self::get_env_send_write(),
         })
     }
 

--- a/vaccel-rpc-proto/protos/genop.proto
+++ b/vaccel-rpc-proto/protos/genop.proto
@@ -44,6 +44,7 @@ message Arg {
 	uint32 custom_type_id = 4;
 	uint32 parts = 5;
 	uint32 part_no = 6;
+	bool unallocated = 7;
 }
 
 message Request {

--- a/vaccel-rpc-proto/src/extensions/arg.rs
+++ b/vaccel-rpc-proto/src/extensions/arg.rs
@@ -4,10 +4,34 @@ use crate::genop::{Arg, ArgType};
 use protobuf::Enum;
 use vaccel::{Arg as VaccelArg, ArgType as VaccelArgType, Error, Result};
 
+impl Arg {
+    pub fn try_from_vaccel_unallocated(vaccel: &VaccelArg) -> Result<Self> {
+        Ok(Self {
+            size: vaccel.size().try_into().map_err(|e| {
+                Error::ConversionFailed(format!(
+                    "Could not convert arg `size` to proto `size` [{}]",
+                    e
+                ))
+            })?,
+            arg_type: ArgType::from_i32(u32::from(vaccel.type_()) as i32)
+                .unwrap()
+                .into(),
+            custom_type_id: vaccel.custom_type_id(),
+            unallocated: true,
+            ..Default::default()
+        })
+    }
+}
+
 impl TryFrom<&Arg> for VaccelArg {
     type Error = Error;
 
     fn try_from(arg: &Arg) -> Result<Self> {
+        if arg.unallocated {
+            return Err(Error::ConversionFailed(
+                "Cannot convert an unallocated proto `Arg` ref to `Arg`".to_string(),
+            ));
+        }
         if arg.size as usize != arg.buf.len() {
             return Err(Error::ConversionFailed(format!(
                 "Could not convert proto `Arg` to `Arg`: Incorrect size; expected {} got {}",
@@ -27,15 +51,26 @@ impl TryFrom<Arg> for VaccelArg {
     type Error = Error;
 
     fn try_from(arg: Arg) -> Result<Self> {
-        if arg.size as usize != arg.buf.len() {
-            return Err(Error::ConversionFailed(format!(
-                "Could not convert proto `Arg` to `Arg`: Incorrect size; expected {} got {}",
-                arg.buf.len(),
-                arg.size,
-            )));
-        }
+        let buf = if arg.unallocated {
+            if arg.size == 0 {
+                return Err(Error::ConversionFailed(
+                    "Could not convert proto `Arg` to `Arg`: Arg is unallocated but size=0"
+                        .to_string(),
+                ));
+            }
+            vec![0u8; arg.size as usize]
+        } else {
+            if arg.size as usize != arg.buf.len() {
+                return Err(Error::ConversionFailed(format!(
+                    "Could not convert proto `Arg` to `Arg`: Incorrect size; expected {} got {}",
+                    arg.buf.len(),
+                    arg.size,
+                )));
+            }
+            arg.buf
+        };
         Self::from_buf(
-            arg.buf,
+            buf,
             VaccelArgType::from(arg.arg_type.value() as u32),
             arg.custom_type_id,
         )
@@ -46,8 +81,9 @@ impl TryFrom<&VaccelArg> for Arg {
     type Error = Error;
 
     fn try_from(vaccel: &VaccelArg) -> Result<Self> {
+        let buf = vaccel.buf().unwrap_or(&[]);
         Ok(Self {
-            buf: vaccel.buf().unwrap_or(&[]).to_vec(),
+            buf: buf.to_vec(),
             size: vaccel.size().try_into().map_err(|e| {
                 Error::ConversionFailed(format!(
                     "Could not convert arg `size` to proto `size` [{}]",
@@ -58,6 +94,7 @@ impl TryFrom<&VaccelArg> for Arg {
                 .unwrap()
                 .into(),
             custom_type_id: vaccel.custom_type_id(),
+            unallocated: buf.is_empty(),
             ..Default::default()
         })
     }


### PR DESCRIPTION
Add `VACCEL_RPC_SEND_WRITE_ENABLED` environment variable to control whether genop write arg buffers will be sent to the agent or not. If the buffers are not sent, the agent will allocate empty ones.