### PR TITLE
ci: Add release orchestration and improve code style

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,15 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      # Workaround for https://github.com/dependabot/dependabot-core/issues/6345
+      - "/.github/actions/*"
     schedule:
       interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     commit-message:
       prefix: "ci(deps)"

--- a/.github/linters/licenserc.yml
+++ b/.github/linters/licenserc.yml
@@ -1,0 +1,41 @@
+header:
+  license:
+    spdx-id: Apache-2.0-short
+    content: |
+      SPDX-License-Identifier: Apache-2.0
+
+    pattern: |
+      Licensed under the Apache License, Version 2.0 \(the "License"\);
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+  paths-ignore:
+    - '**/.*'
+    - '**/*.md'
+    - '**/*.txt'
+    - '**/*.build'
+    - '**/*.options'
+    - '**/*.cmake'
+    - '**/*.cmake.in'
+    - '**/*.pc.in'
+    - '**/*.toml'
+    - '**/*.j2'
+    - '.github/*.yml'
+    - '.github/*.yaml'
+    - '.github/*.json'
+    - '.github/linters'
+    - 'LICENSE'
+    - 'NOTICE'
+    - 'subprojects'
+    - 'third-party'
+    - 'target'
+
+  comment: on-failure

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "configMigration": true,
+  "extends": [
+    "config:recommended",
+    ":gitSignOff",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(build)",
+    ":semanticCommitScope(deps)"
+  ],
+  "prHourlyLimit": 5,
+  "labels": ["dependencies", "cargo"],
+  "commitMessageLowerCase": "never",
+  "commitBodyTable": true,
+  "enabledManagers": ["cargo"],
+  "packageRules": [
+    {
+      "groupName": "Cargo",
+      "matchManagers": ["cargo"],
+      "matchPackageNames": ["*"]
+    }
+  ]
+}

--- a/.github/workflows/main-build-and-upload.yml
+++ b/.github/workflows/main-build-and-upload.yml
@@ -9,6 +9,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
+permissions: read-all
+
 jobs:
   build-dist:
     name: Build and Upload

--- a/.github/workflows/main-build-and-upload.yml
+++ b/.github/workflows/main-build-and-upload.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: Build and Upload
 
 on:

--- a/.github/workflows/main-build-and-upload.yml
+++ b/.github/workflows/main-build-and-upload.yml
@@ -20,3 +20,13 @@ jobs:
       options: 'rpc-client=enabled,rpc-agent=enabled'
       upload-subpath: 'rust'
     secrets: inherit
+
+  update-release:
+    needs: build-dist
+    name: Update Release
+    if: always()
+    uses: nubificus/vaccel/.github/workflows/update-release.yml@main
+    with:
+      artifacts-path: 'rust'
+      result: ${{ needs.build-dist.result }}
+    secrets: inherit

--- a/.github/workflows/pr-build-and-verify.yml
+++ b/.github/workflows/pr-build-and-verify.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: Build and Verify
 
 on:

--- a/.github/workflows/pr-build-and-verify.yml
+++ b/.github/workflows/pr-build-and-verify.yml
@@ -8,8 +8,11 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
+permissions: read-all
 
 jobs:
   check-pr-status:
@@ -20,7 +23,7 @@ jobs:
 #  test-build:
 #    needs: check-pr-status
 #    name: Test Build
-#    if: ${{ needs.check-pr-status.outputs.expects-checks == 'true' }}
+#    if: needs.check-pr-status.outputs.expects-checks == 'true'
 #    uses: nubificus/vaccel/.github/workflows/test-build.yml@main
 #    with:
 #      runner: '["base", "dind", "2204"]'
@@ -32,7 +35,7 @@ jobs:
   verify-build:
     needs: check-pr-status
     name: Verify Build
-    if: ${{ needs.check-pr-status.outputs.expects-checks == 'true' }}
+    if: needs.check-pr-status.outputs.expects-checks == 'true'
     uses: nubificus/vaccel/.github/workflows/verify-build.yml@main
     with:
       runner: '["base", "dind", "2204"]'
@@ -46,14 +49,14 @@ jobs:
   validate-files-and-commits:
     needs: check-pr-status
     name: Validate Files and Commits
-    if: ${{ needs.check-pr-status.outputs.expects-checks == 'true' }}
+    if: needs.check-pr-status.outputs.expects-checks == 'true'
     uses: nubificus/vaccel/.github/workflows/validate-files-and-commits.yml@main
     secrets: inherit
 
   validate-code:
     needs: check-pr-status
     name: Validate Code
-    if: ${{ needs.check-pr-status.outputs.expects-checks == 'true' }}
+    if: needs.check-pr-status.outputs.expects-checks == 'true'
     uses: ./.github/workflows/validate-code.yml
     with:
       runner: '["base", "dind", "2204"]'
@@ -80,11 +83,11 @@ jobs:
       - validate-code
     name: Jobs Completed
     if: >-
-      ${{ always() &&
-        (needs.check-pr-status.outputs.is-approved == 'true' ||
-          (needs.check-pr-status.outputs.expects-checks == 'true' &&
-            !contains(needs.*.result, 'failure') &&
-            !contains(needs.*.result, 'cancelled'))) }}
+      always() &&
+      (needs.check-pr-status.outputs.is-approved == 'true' ||
+        (needs.check-pr-status.outputs.expects-checks == 'true' &&
+          !contains(needs.*.result, 'failure') &&
+          !contains(needs.*.result, 'cancelled')))
     runs-on: base-2204-amd64
     steps:
       - run: exit 0

--- a/.github/workflows/pr-trailers.yml
+++ b/.github/workflows/pr-trailers.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: Add Git Trailers to PR commits
 
 on:

--- a/.github/workflows/pr-trailers.yml
+++ b/.github/workflows/pr-trailers.yml
@@ -7,12 +7,15 @@ on:
     types: [synchronize, labeled]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+permissions: read-all
 
 jobs:
 #  commit-coverage:
 #    name: Commit coverage report
-#    if: ${{ github.event.review.state == 'approved' }}
+#    if: github.event.review.state == 'approved'
 #    uses: ./.github/workflows/coverage-report.yml
 #    with:
 #      commit: true
@@ -22,7 +25,7 @@ jobs:
   check-pr-status:
 #    needs: commit-coverage
     name: Check PR status
-    if: ${{ always() && github.event.pull_request.base.ref == 'main' }}
+    if: always() && github.event.pull_request.base.ref == 'main'
     uses: nubificus/vaccel/.github/workflows/check-pr-status.yml@main
     with:
       pr-number: >-
@@ -34,7 +37,8 @@ jobs:
     needs: check-pr-status
     name: Add Git Trailers to PR commits
     if: >-
-      ${{ always() && github.event.pull_request.base.ref == 'main' &&
-        needs.check-pr-status.outputs.is-approved == 'true' }}
+      always() &&
+      github.event.pull_request.base.ref == 'main' &&
+      needs.check-pr-status.outputs.is-approved == 'true'
     uses: nubificus/vaccel/.github/workflows/add-git-trailers.yml@main
     secrets: inherit

--- a/.github/workflows/schedule-renovate.yml
+++ b/.github/workflows/schedule-renovate.yml
@@ -1,0 +1,51 @@
+name: Renovate Updates
+
+on:
+  schedule:
+    - cron: '0 4 1 * *'
+  push:
+    branches: ["main"]
+  issues:
+    types: [edited]
+  pull_request:
+    types: [edited]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  update:
+    name: Update
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
+      (github.event_name == 'issues' &&
+        github.event.issue.title == 'Dependency Dashboard') ||
+      (github.event_name == 'pull_request' &&
+        startsWith(github.event.pull_request.title, 'build(deps):'))
+    runs-on: base-dind-2204-amd64
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Generate vaccel-bot token
+        id: generate-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.VACCEL_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.VACCEL_BOT_PRIVATE_KEY }}
+          permission-metadata: read
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@v46.1.9
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          configurationFile: .github/renovate.json

--- a/.github/workflows/schedule-renovate.yml
+++ b/.github/workflows/schedule-renovate.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: Renovate Updates
 
 on:

--- a/.github/workflows/schedule-renovate.yml
+++ b/.github/workflows/schedule-renovate.yml
@@ -15,6 +15,8 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
+permissions: read-all
+
 jobs:
   update:
     name: Update

--- a/.github/workflows/schedule-update-notice.yml
+++ b/.github/workflows/schedule-update-notice.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: Update NOTICE
 
 on:

--- a/.github/workflows/schedule-update-notice.yml
+++ b/.github/workflows/schedule-update-notice.yml
@@ -1,0 +1,18 @@
+name: Update NOTICE
+
+on:
+  schedule:
+    # 00:05 UTC on January 1st every year
+    - cron: '5 0 1 1 *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+permissions: read-all
+
+jobs:
+  update-notice:
+    name: Update NOTICE Year
+    uses: nubificus/vaccel/.github/workflows/update-notice-year.yml@main
+    secrets: inherit

--- a/.github/workflows/validate-code.yml
+++ b/.github/workflows/validate-code.yml
@@ -6,7 +6,7 @@ on:
       actions-repo:
         type: string
         default: 'nubificus/vaccel'
-      actions-rev:
+      actions-ref:
         type: string
         default: 'main'
       runner:
@@ -29,10 +29,13 @@ on:
       AWS_SECRET_ACCESS_KEY:
         required: false
 
+permissions: read-all
+
 jobs:
   linter-rust-clippy:
     name: Lint Rust (rust-clippy)
-    runs-on: ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.arch) }}
+    runs-on: >-
+      ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.arch) }}
     strategy:
       matrix:
         arch: ["${{ fromJSON(inputs.runner-archs) }}"]
@@ -40,9 +43,9 @@ jobs:
       fail-fast: false
     env:
       ARCH: ${{ fromJson(inputs.runner-arch-map)[0][matrix.arch] }}
-      DOWNLOAD_PATH: ${{github.workspace}}/artifacts/downloads/${{fromJson(inputs.runner-arch-map)[0][matrix.arch]}}/${{matrix.build-type}}
-      CC: gcc-12
-      CXX: g++-12
+      DOWNLOAD_PATH: >-
+        ${{ format('{0}/artifacts/downloads/{1}/{2}', github.workspace,
+          fromJson(inputs.runner-arch-map)[0][matrix.arch], matrix.build-type) }}
     steps:
       - name: Parse repository names
         id: parse-repos
@@ -68,11 +71,11 @@ jobs:
           permission-contents: read
 
       - name: Checkout .github directory
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           sparse-checkout: .github
           repository: ${{ inputs.actions-repo }}
-          ref: ${{ inputs.actions-rev }}
+          ref: ${{ inputs.actions-ref }}
           token: ${{ steps.generate-init-token.outputs.token || github.token }}
 
       - name: Initialize workspace
@@ -85,10 +88,12 @@ jobs:
 
       - name: Download artifacts from s3
         id: download-artifacts
-        if: ${{ inputs.actions-repo != github.repository }}
+        if: inputs.actions-repo != github.repository
         uses: ./.github/actions/download-from-s3
         with:
-          branch: ${{ steps.initialize-workspace.outputs.remote-branch }}
+          ref: >-
+            ${{ steps.initialize-workspace.outputs.remote-tag ||
+              steps.initialize-workspace.outputs.remote-branch }}
           build-type: ${{ matrix.build-type }}
           arch: ${{ env.ARCH }}
           access-key: ${{ secrets.AWS_ACCESS_KEY }}
@@ -108,23 +113,23 @@ jobs:
         shell: bash
 
       - name: Clean-up
-        if: ${{ always() }}
+        if: always()
+        env:
+          INSTALLED: ${{ steps.download-artifacts.outputs.installed }}
         run: |
-          sudo apt-get purge -y \
-            ${{ steps.download-artifacts.outputs.installed }} || echo
+          sudo rm -rf target*
+          sudo apt-get purge -y "$INSTALLED" || true
         shell: bash
 
   linter-rust-fmt:
     name: Lint Rust (rust-fmt)
-    runs-on: ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.arch) }}
+    runs-on: >-
+      ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.arch) }}
     strategy:
       matrix:
         arch: ["${{ fromJSON(inputs.runner-archs) }}"]
         build-type: [release]
       fail-fast: false
-    env:
-      CC: gcc-12
-      CXX: g++-12
     steps:
       - name: Parse repository names
         id: parse-repos
@@ -150,11 +155,11 @@ jobs:
           permission-contents: read
 
       - name: Checkout .github directory
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           sparse-checkout: .github
           repository: ${{ inputs.actions-repo }}
-          ref: ${{ inputs.actions-rev }}
+          ref: ${{ inputs.actions-ref }}
           token: ${{ steps.generate-init-token.outputs.token || github.token }}
 
       - name: Initialize workspace
@@ -171,7 +176,8 @@ jobs:
 
   linter-super-linter:
     name: Lint Shell/GHActions/Markdown/YAML
-    runs-on: ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.arch) }}
+    runs-on: >-
+      ${{ format('{0}-{1}', join(fromJSON(inputs.runner), '-'), matrix.arch) }}
     strategy:
       matrix:
         arch: ["${{ fromJSON(inputs.runner-archs) }}"]
@@ -202,11 +208,11 @@ jobs:
           permission-contents: read
 
       - name: Checkout .github directory
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           sparse-checkout: .github
           repository: ${{ inputs.actions-repo }}
-          ref: ${{ inputs.actions-rev }}
+          ref: ${{ inputs.actions-ref }}
           token: ${{ steps.generate-init-token.outputs.token || github.token }}
 
       - name: Initialize workspace
@@ -233,7 +239,7 @@ jobs:
         env:
           GITHUB_TOKEN: >-
             ${{ steps.generate-linter-token.outputs.token || github.token }}
-          ENABLE_GITHUB_ACTIONS_STEP_SUMMARY: false
+          ENABLE_GITHUB_PULL_REQUEST_SUMMARY_COMMENT: false
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_BASH: true
           VALIDATE_SHELL_SHFMT: true

--- a/.github/workflows/validate-code.yml
+++ b/.github/workflows/validate-code.yml
@@ -22,7 +22,7 @@ on:
         type: string
         default: 'async,async-stream'
     secrets:
-      GIT_CLONE_PAT:
+      VACCEL_BOT_PRIVATE_KEY:
         required: false
       AWS_ACCESS_KEY:
         required: false
@@ -38,21 +38,42 @@ jobs:
         arch: ["${{ fromJSON(inputs.runner-archs) }}"]
         build-type: [release]
       fail-fast: false
-    permissions:
-      contents: read
-      pull-requests: write
     env:
       ARCH: ${{ fromJson(inputs.runner-arch-map)[0][matrix.arch] }}
       DOWNLOAD_PATH: ${{github.workspace}}/artifacts/downloads/${{fromJson(inputs.runner-arch-map)[0][matrix.arch]}}/${{matrix.build-type}}
       CC: gcc-12
       CXX: g++-12
     steps:
+      - name: Parse repository names
+        id: parse-repos
+        env:
+          ACTIONS_REPO: ${{ inputs.actions-repo }}
+        run: |
+          {
+            echo "repo-name=$(basename "$GITHUB_REPOSITORY")"
+            echo "actions-repo-name=$(basename "$ACTIONS_REPO")"
+          } >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Generate initialization vaccel-bot token
+        id: generate-init-token
+        if: vars.VACCEL_BOT_CLIENT_ID
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.VACCEL_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.VACCEL_BOT_PRIVATE_KEY }}
+          repositories: |
+            ${{ steps.parse-repos.outputs.repo-name }}
+            ${{ steps.parse-repos.outputs.actions-repo-name }}
+          permission-contents: read
+
       - name: Checkout .github directory
         uses: actions/checkout@v5
         with:
           sparse-checkout: .github
           repository: ${{ inputs.actions-repo }}
           ref: ${{ inputs.actions-rev }}
+          token: ${{ steps.generate-init-token.outputs.token || github.token }}
 
       - name: Initialize workspace
         id: initialize-workspace
@@ -60,7 +81,7 @@ jobs:
         with:
           fetch-depth: 0
           remote-actions-repo: ${{ inputs.actions-repo }}
-          token: ${{ secrets.GIT_CLONE_PAT || github.token }}
+          token: ${{ steps.generate-init-token.outputs.token || github.token }}
 
       - name: Download artifacts from s3
         id: download-artifacts
@@ -101,19 +122,40 @@ jobs:
         arch: ["${{ fromJSON(inputs.runner-archs) }}"]
         build-type: [release]
       fail-fast: false
-    permissions:
-      contents: read
-      pull-requests: write
     env:
       CC: gcc-12
       CXX: g++-12
     steps:
+      - name: Parse repository names
+        id: parse-repos
+        env:
+          ACTIONS_REPO: ${{ inputs.actions-repo }}
+        run: |
+          {
+            echo "repo-name=$(basename "$GITHUB_REPOSITORY")"
+            echo "actions-repo-name=$(basename "$ACTIONS_REPO")"
+          } >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Generate initialization vaccel-bot token
+        id: generate-init-token
+        if: vars.VACCEL_BOT_CLIENT_ID
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.VACCEL_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.VACCEL_BOT_PRIVATE_KEY }}
+          repositories: |
+            ${{ steps.parse-repos.outputs.repo-name }}
+            ${{ steps.parse-repos.outputs.actions-repo-name }}
+          permission-contents: read
+
       - name: Checkout .github directory
         uses: actions/checkout@v5
         with:
           sparse-checkout: .github
           repository: ${{ inputs.actions-repo }}
           ref: ${{ inputs.actions-rev }}
+          token: ${{ steps.generate-init-token.outputs.token || github.token }}
 
       - name: Initialize workspace
         id: initialize-workspace
@@ -121,7 +163,7 @@ jobs:
         with:
           fetch-depth: 0
           remote-actions-repo: ${{ inputs.actions-repo }}
-          token: ${{ secrets.GIT_CLONE_PAT || github.token }}
+          token: ${{ steps.generate-init-token.outputs.token || github.token }}
 
       - name: Run rust-fmt
         run: cargo fmt --all --check
@@ -135,17 +177,37 @@ jobs:
         arch: ["${{ fromJSON(inputs.runner-archs) }}"]
         build-type: [release]
       fail-fast: false
-    permissions:
-      contents: read
-      packages: read
-      statuses: write
     steps:
+      - name: Parse repository names
+        id: parse-repos
+        env:
+          ACTIONS_REPO: ${{ inputs.actions-repo }}
+        run: |
+          {
+            echo "repo-name=$(basename "$GITHUB_REPOSITORY")"
+            echo "actions-repo-name=$(basename "$ACTIONS_REPO")"
+          } >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Generate initialization vaccel-bot token
+        id: generate-init-token
+        if: vars.VACCEL_BOT_CLIENT_ID
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.VACCEL_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.VACCEL_BOT_PRIVATE_KEY }}
+          repositories: |
+            ${{ steps.parse-repos.outputs.repo-name }}
+            ${{ steps.parse-repos.outputs.actions-repo-name }}
+          permission-contents: read
+
       - name: Checkout .github directory
         uses: actions/checkout@v5
         with:
           sparse-checkout: .github
           repository: ${{ inputs.actions-repo }}
           ref: ${{ inputs.actions-rev }}
+          token: ${{ steps.generate-init-token.outputs.token || github.token }}
 
       - name: Initialize workspace
         id: initialize-workspace
@@ -153,13 +215,24 @@ jobs:
         with:
           fetch-depth: 0
           remote-actions-repo: ${{ inputs.actions-repo }}
-          token: ${{ secrets.GIT_CLONE_PAT || github.token }}
+          token: ${{ steps.generate-init-token.outputs.token || github.token }}
+
+      - name: Generate linter vaccel-bot token
+        id: generate-linter-token
+        if: vars.VACCEL_BOT_CLIENT_ID
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.VACCEL_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.VACCEL_BOT_PRIVATE_KEY }}
+          permission-contents: read
+          permission-packages: read
+          permission-statuses: write
 
       - name: Run super-linter
         uses: super-linter/super-linter@v8
         env:
-          DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: >-
+            ${{ steps.generate-linter-token.outputs.token || github.token }}
           ENABLE_GITHUB_ACTIONS_STEP_SUMMARY: false
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_BASH: true

--- a/.github/workflows/validate-code.yml
+++ b/.github/workflows/validate-code.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 name: Validate Source Code
 
 on:

--- a/meson.build
+++ b/meson.build
@@ -3,9 +3,10 @@ project('vaccel-rust', 'c', 'rust',
   license : 'Apache-2.0',
   license_files : 'LICENSE',
   version : run_command('sh', '-c',
-    'git submodule update --init >/dev/null && ' +
-    'scripts/common/generate-version.sh . --no-dirty',
-    check: false).stdout().strip())
+    '(git submodule update --init >/dev/null 2>&1 || true) && ' +
+    'scripts/common/generate-version.sh',
+    env: {'SH_SCRIPTS_DIR': meson.project_source_root() / 'scripts' / 'common'},
+    check: true).stdout().strip())
 
 cargo_bin = find_program('cargo', version : '>=1.64.0', required : true)
 cargo_meson_sh = files(meson.project_source_root() + '/scripts/common/cargo.sh')
@@ -156,36 +157,33 @@ summary({
   section : 'Configuration',
   bool_yn : true)
 
-# only build binary dist/deb for vaccel-rpc-agent,
-# we ship the client lib with the plugin.
-if opt_rpc_agent.enabled() and not meson.is_subproject()
+version_only = meson.is_subproject() ? '--version-only' : ''
+
+# Build rpc agent/client as separate packages
+if opt_rpc_agent.enabled()
   meson.add_dist_script(
     'scripts/common/dist.sh',
-    'vaccel-rpc-agent',
-    get_option('buildtype'),
-    'async',
-    opt_async.enabled() ? 'enabled' : 'disabled',
-    'async-stream',
-    opt_async_stream.enabled() ? 'enabled' : 'disabled',
-    'rpc-client',
-    'disabled',
-    'rpc-agent',
-    'enabled',
-    )
+    '-n', 'vaccel-rpc-agent',
+    '-v', meson.project_version(),
+    '-t', get_option('buildtype'),
+    '--pkg-config-path', ':'.join(get_option('pkg_config_path')),
+    '-a', 'async=' + (opt_async.enabled() ? 'enabled' : 'disabled'),
+    '-a', 'async-stream=' + (opt_async_stream.enabled() ? 'enabled' : 'disabled'),
+    '-a', 'rpc-client=disabled',
+    '-a', 'rpc-agent=enabled',
+    version_only)
 endif
 
-if opt_rpc_client.enabled() and not meson.is_subproject()
+if opt_rpc_client.enabled()
   meson.add_dist_script(
     'scripts/common/dist.sh',
-    'vaccel-rpc-client',
-    get_option('buildtype'),
-    'async',
-    opt_async.enabled() ? 'enabled' : 'disabled',
-    'async-stream',
-    opt_async_stream.enabled() ? 'enabled' : 'disabled',
-    'rpc-client',
-    'enabled',
-    'rpc-agent',
-    'disabled',
-    )
+    '-n', 'vaccel-rpc-client',
+    '-v', meson.project_version(),
+    '-t', get_option('buildtype'),
+    '--pkg-config-path', ':'.join(get_option('pkg_config_path')),
+    '-a', 'async=' + (opt_async.enabled() ? 'enabled' : 'disabled'),
+    '-a', 'async-stream=' + (opt_async_stream.enabled() ? 'enabled' : 'disabled'),
+    '-a', 'rpc-client=enabled',
+    '-a', 'rpc-agent=disabled',
+    version_only)
 endif


### PR DESCRIPTION
Add release orchestration and improve CI code style:
- Integrate automatic release orchestration introduced in https://github.com/nubificus/vaccel/pull/210
- Replace PAT with `vaccel-bot` tokens, scoped per step
- Group Dependabot updates, including custom actions
- Add Renovate Cargo dependency update workflow
- Add annual copyright year bump workflow
- Add SPDX license headers, tidy up workflow code style and bump dependencies
- Update meson/scripts for the new dist/component versioning scheme